### PR TITLE
Feature/tools-hide-option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21362,6 +21362,9 @@
         "send": "0.17.1"
       }
     },
+    "servicemap-ui-turku": {
+      "version": "file:../servicemap-ui-turku"
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "redux-thunk": "^2.3.0",
     "regenerator-runtime": "^0.13.7",
     "reselect": "^4.0.0",
+    "servicemap-ui-turku": "file:../servicemap-ui-turku",
     "sitemap": "^6.4.0",
     "urijs": "^1.19.2",
     "whatwg-fetch": "^3.5.0",

--- a/server/server.js
+++ b/server/server.js
@@ -232,6 +232,7 @@ const htmlTemplate = (req, reactDom, preloadedState, css, cssString, locale, hel
         window.nodeEnvSettings.FEEDBACK_IS_PUBLISHED = "${process.env.FEEDBACK_IS_PUBLISHED}";
         window.nodeEnvSettings.USE_PTV_ACCESSIBILITY_API = "${process.env.USE_PTV_ACCESSIBILITY_API}";
         window.nodeEnvSettings.SENTRY_DSN_CLIENT = "${process.env.SENTRY_DSN_CLIENT}";
+        window.nodeEnvSettings.THEME_PKG = "${process.env.THEME_PKG}";
 
         window.appVersion = {};
         window.appVersion.tag = "${versionTag}";

--- a/src/views/EmbedderView/EmbedderView.js
+++ b/src/views/EmbedderView/EmbedderView.js
@@ -1,12 +1,11 @@
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import {
-  Typography, Paper, TextField,
-} from '@material-ui/core';
+import { Typography, Paper, TextField } from '@material-ui/core';
 import URI from 'urijs';
 import { Helmet } from 'react-helmet';
 import { useSelector } from 'react-redux';
+import { isTurku } from 'servicemap-ui-turku/scripts/currentLocation';
 import * as smurl from './utils/url';
 import isClient, { uppercaseFirst } from '../../utils';
 import { getEmbedURL, getLanguage } from './utils/utils';
@@ -20,11 +19,7 @@ import SettingsUtility from '../../utils/settings';
 import useLocaleText from '../../utils/useLocaleText';
 import { useUserLocale } from '../../utils/user';
 
-
-const hideCitiesIn = [
-  paths.unit.regex,
-  paths.address.regex,
-];
+const hideCitiesIn = [paths.unit.regex, paths.address.regex];
 
 const hideServicesIn = [
   paths.search.regex,
@@ -40,11 +35,7 @@ let timeout;
 const timeoutDelay = 1000;
 
 const EmbedderView = ({
-  citySettings,
-  classes,
-  intl,
-  mapType,
-  navigator,
+  citySettings, classes, intl, mapType, navigator,
 }) => {
   // Verify url
   const data = isClient() ? smurl.verify(window.location.href) : {};
@@ -61,9 +52,7 @@ const EmbedderView = ({
   }
 
   const cityOption = (search?.city !== '' && search?.city?.split(',')) || citySettings;
-  const citiesToReduce = cityOption.length > 0
-    ? cityOption
-    : embedderConfig.CITIES.filter(v => v);
+  const citiesToReduce = cityOption.length > 0 ? cityOption : embedderConfig.CITIES.filter(v => v);
 
   // Defaults
   const initialRatio = ratio || 52;
@@ -87,7 +76,9 @@ const EmbedderView = ({
   const [map, setMap] = useState(defaultMap);
   const [city, setCity] = useState(defaultCities);
   const [service, setService] = useState(defaultService);
-  const [customWidth, setCustomWidth] = useState(embedderConfig.DEFAULT_CUSTOM_WIDTH || 100);
+  const [customWidth, setCustomWidth] = useState(
+    embedderConfig.DEFAULT_CUSTOM_WIDTH || 100,
+  );
   const [widthMode, setWidthMode] = useState('auto');
   const [fixedHeight, setFixedHeight] = useState(defaultFixedHeight);
   const [ratioHeight, setRatioHeight] = useState(initialRatio);
@@ -99,7 +90,13 @@ const EmbedderView = ({
 
   const renderWrapperStyle = () => `position: relative; width:100%; padding-bottom:${ratioHeight}%;`;
   const embedUrl = getEmbedURL(url, {
-    language, map, city, service, defaultLanguage, transit, showUnits,
+    language,
+    map,
+    city,
+    service,
+    defaultLanguage,
+    transit,
+    showUnits,
   });
 
   const getTitleText = () => {
@@ -167,21 +164,28 @@ const EmbedderView = ({
     }
     let height;
     let html;
-    if (heightMode === 'fixed') { height = fixedHeight; }
+    if (heightMode === 'fixed') {
+      height = fixedHeight;
+    }
     if (heightMode === 'ratio') {
       if (widthMode === 'auto') {
         html = `<div style="${renderWrapperStyle()}">
           <iframe title="${iframeTitle}" style="position: absolute; top: 0; left: 0; border: none; width: 100%; height: 100%;"
           src="${embedUrl}"></iframe></div>`;
       } else {
-        height = parseInt(parseInt(customWidth, 10) * (parseInt(ratioHeight, 10) / 100.0), 10);
+        height = parseInt(
+          parseInt(customWidth, 10) * (parseInt(ratioHeight, 10) / 100.0),
+          10,
+        );
       }
     }
 
     if (height) {
-      const width = widthMode !== 'custom' ? (
-        iframeConfig.style && iframeConfig.style.width && iframeConfig.style.width
-      ) : customWidth;
+      const width = widthMode !== 'custom'
+        ? iframeConfig.style
+            && iframeConfig.style.width
+            && iframeConfig.style.width
+        : customWidth;
       const widthUnit = width !== '100%' ? 'px' : '';
       html = `<iframe title="${iframeTitle}" style="border: none; width: ${width}${widthUnit}; height: ${height}px;"
                   src="${embedUrl}"></iframe>`;
@@ -220,9 +224,7 @@ const EmbedderView = ({
 
     return (
       <Paper className={classes.formContainerPaper}>
-        {
-          /* Embed address */
-        }
+        {/* Embed address */}
         <Typography
           align="left"
           className={classes.marginBottom}
@@ -237,11 +239,11 @@ const EmbedderView = ({
           value={embedUrl}
           margin="normal"
           variant="outlined"
-          inputProps={{ 'aria-label': intl.formatMessage({ id: 'embedder.url.title' }) }}
+          inputProps={{
+            'aria-label': intl.formatMessage({ id: 'embedder.url.title' }),
+          }}
         />
-        {
-          /* Embed HTML code */
-        }
+        {/* Embed HTML code */}
         <Typography
           align="left"
           className={classes.marginBottom}
@@ -250,9 +252,7 @@ const EmbedderView = ({
         >
           <FormattedMessage id="embedder.code.title" />
         </Typography>
-        <pre className={classes.pre}>
-          { htmlText }
-        </pre>
+        <pre className={classes.pre}>{htmlText}</pre>
       </Paper>
     );
   };
@@ -264,14 +264,18 @@ const EmbedderView = ({
     const description = locale => intl.formatMessage({ id: `embedder.language.description.${locale}` });
     const languageControls = generateLabel => Object.keys(embedderConfig.LANGUAGES).map(lang => ({
       value: lang,
-      label: `${uppercaseFirst(embedderConfig.LANGUAGES[userLocale][lang])}. ${generateLabel(lang)}`,
+      label: `${uppercaseFirst(
+        embedderConfig.LANGUAGES[userLocale][lang],
+      )}. ${generateLabel(lang)}`,
     }));
 
     return (
       <EmbedController
         titleID="embedder.language.title"
         titleComponent="h2"
-        radioAriaLabel={intl.formatMessage({ id: 'embedder.language.aria.label' })}
+        radioAriaLabel={intl.formatMessage({
+          id: 'embedder.language.aria.label',
+        })}
         radioName="language"
         radioValue={language}
         radioControls={languageControls(description)}
@@ -350,7 +354,9 @@ const EmbedderView = ({
       <EmbedController
         titleID="embedder.service.title"
         titleComponent="h2"
-        radioAriaLabel={intl.formatMessage({ id: 'embedder.service.aria.label' })}
+        radioAriaLabel={intl.formatMessage({
+          id: 'embedder.service.aria.label',
+        })}
         radioName="service"
         radioValue={service}
         radioControls={serviceControls(getLabel)}
@@ -422,7 +428,9 @@ const EmbedderView = ({
       <EmbedController
         titleID="embedder.height.title"
         titleComponent="h2"
-        radioAriaLabel={intl.formatMessage({ id: 'embedder.height.aria.label' })}
+        radioAriaLabel={intl.formatMessage({
+          id: 'embedder.height.aria.label',
+        })}
         radioName="height"
         radioValue={heightMode}
         radioControls={controls}
@@ -444,22 +452,35 @@ const EmbedderView = ({
   };
 
   const renderMapOptionsControl = () => {
-    const controls = [
-      {
-        key: 'transit',
-        value: transit,
-        onChange: v => setTransit(v),
-        icon: null,
-        labelId: 'embedder.options.label.transit',
-      },
-      {
-        key: 'units',
-        value: showUnits,
-        onChange: v => setShowUnits(v),
-        icon: null,
-        labelId: 'embedder.options.label.units',
-      },
-    ];
+    let controls = [];
+    if (isTurku) {
+      controls = [
+        {
+          key: 'units',
+          value: showUnits,
+          onChange: v => setShowUnits(v),
+          icon: null,
+          labelId: 'embedder.options.label.units',
+        },
+      ];
+    } else {
+      controls = [
+        {
+          key: 'transit',
+          value: transit,
+          onChange: v => setTransit(v),
+          icon: null,
+          labelId: 'embedder.options.label.transit',
+        },
+        {
+          key: 'units',
+          value: showUnits,
+          onChange: v => setShowUnits(v),
+          icon: null,
+          labelId: 'embedder.options.label.units',
+        },
+      ];
+    }
 
     return (
       <EmbedController
@@ -474,7 +495,9 @@ const EmbedderView = ({
   const renderHeadInfo = () => (
     <Helmet>
       <title>
-        {`${intl.formatMessage({ id: 'embedder.title' })} | ${intl.formatMessage({ id: 'app.title' })}`}
+        {`${intl.formatMessage({
+          id: 'embedder.title',
+        })} | ${intl.formatMessage({ id: 'app.title' })}`}
       </title>
     </Helmet>
   );
@@ -485,16 +508,15 @@ const EmbedderView = ({
 
   return (
     <div ref={dialogRef}>
-      {
-        renderHeadInfo()
-      }
+      {renderHeadInfo()}
       <div className={classes.appBar} />
       <div className={classes.container}>
-        <div style={{
-          display: 'flex',
-          flexDirection: 'row',
-          position: 'relative',
-        }}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            position: 'relative',
+          }}
         >
           <CloseButton
             aria-label={intl.formatMessage({ id: 'embedder.close' })}
@@ -515,24 +537,12 @@ const EmbedderView = ({
         </div>
         <div className={classes.formContainer}>
           <form>
-            {
-              renderLanguageControl()
-            }
-            {
-              renderServiceControl()
-            }
-            {
-              renderMapTypeControl()
-            }
-            {
-              renderCityControl()
-            }
-            {
-              renderWidthControl()
-            }
-            {
-              renderHeightControl()
-            }
+            {renderLanguageControl()}
+            {renderServiceControl()}
+            {renderMapTypeControl()}
+            {renderCityControl()}
+            {renderWidthControl()}
+            {renderHeightControl()}
             <IFramePreview
               classes={classes}
               customWidth={customWidth}
@@ -545,13 +555,9 @@ const EmbedderView = ({
               widthMode={widthMode}
             />
 
-            {
-              renderMapOptionsControl()
-            }
+            {renderMapOptionsControl()}
           </form>
-          {
-            renderEmbedHTML()
-          }
+          {renderEmbedHTML()}
           <SMButton
             aria-label={intl.formatMessage({ id: 'embedder.close' })}
             className={classes.button}
@@ -561,7 +567,6 @@ const EmbedderView = ({
             messageID="embedder.close"
           />
         </div>
-
       </div>
     </div>
   );
@@ -597,6 +602,5 @@ EmbedderView.defaultProps = {
   navigator: null,
   mapType: null,
 };
-
 
 export default EmbedderView;

--- a/src/views/EmbedderView/EmbedderView.js
+++ b/src/views/EmbedderView/EmbedderView.js
@@ -5,7 +5,6 @@ import { Typography, Paper, TextField } from '@material-ui/core';
 import URI from 'urijs';
 import { Helmet } from 'react-helmet';
 import { useSelector } from 'react-redux';
-import { isTurku } from 'servicemap-ui-turku/scripts/currentLocation';
 import * as smurl from './utils/url';
 import isClient, { uppercaseFirst } from '../../utils';
 import { getEmbedURL, getLanguage } from './utils/utils';
@@ -453,7 +452,7 @@ const EmbedderView = ({
 
   const renderMapOptionsControl = () => {
     let controls = [];
-    if (isTurku) {
+    if (window.nodeEnvSettings.THEME_PKG) {
       controls = [
         {
           key: 'units',


### PR DESCRIPTION
# Hides transit option inside the embedding tool.

## Breakdown:
Hides the transit option from embedding tool, because servicemap of Turku does not yet show bus stops on the map.

### New env variable
1. server/server.js
    * Add new env variable into window, so it can be used inside components.

### Edit options control array
1.  src/views/EmbedderView/EmbedderView.js
     * Checks if the new env value is true and only renders units. If it's false, renders also the transit option. Also contains some linting changes to code, which can be ignored. Actual changes can be seen between lines 453 and 482.

### Install Turku theme
1.  package.json
     * Install Turku theme as a dependency.