### PR TITLE
Fix/bicycle-stands-error

### DIFF
--- a/src/components/MobilityPlatform/BicycleStands/BicycleStands.js
+++ b/src/components/MobilityPlatform/BicycleStands/BicycleStands.js
@@ -29,7 +29,7 @@ const BicycleStands = ({ classes }) => {
 
   useEffect(() => {
     const filtered = [];
-    if (bicycleStands !== null) {
+    if (bicycleStands !== null && openMobilityPlatform) {
       bicycleStands.forEach((item) => {
         if (item.extra.maintained_by_turku === true) {
           filtered.push(item);
@@ -37,7 +37,7 @@ const BicycleStands = ({ classes }) => {
       });
     }
     setMaintainedBicycleStands(filtered);
-  }, [bicycleStands]);
+  }, [openMobilityPlatform, bicycleStands]);
 
   return (
     <>


### PR DESCRIPTION
# Fix bug in the filter -function

## Breakdown:
App crashed because filter function was called before the GET-request because of missing state requirement. This fixes that.

### Add state into the function
1. src/components/MobilityPlatform/BicycleStands/BicycleStands.js
    * Add state variable into the filter -function to prevent it from running before GET-request fetches data.