### PR TITLE
fix/bicycle-stands-error

### DIFF
--- a/src/components/MobilityPlatform/BicycleStands/BicycleStands.js
+++ b/src/components/MobilityPlatform/BicycleStands/BicycleStands.js
@@ -29,14 +29,14 @@ const BicycleStands = ({ classes }) => {
 
   useEffect(() => {
     const filtered = [];
-    if (bicycleStands !== null && openMobilityPlatform) {
+    if (bicycleStands && openMobilityPlatform) {
       bicycleStands.forEach((item) => {
         if (item.extra.maintained_by_turku === true) {
           filtered.push(item);
         }
       });
+      setMaintainedBicycleStands(filtered);
     }
-    setMaintainedBicycleStands(filtered);
   }, [openMobilityPlatform, bicycleStands]);
 
   return (


### PR DESCRIPTION
# Fix a bug inside the filter -function

## Breakdown:
App crashed because filter function received undefined value. This fixes that.

### Fix the filter -function
1. src/components/MobilityPlatform/BicycleStands/BicycleStands.js
    * If statement inside the function will not accept undefined values anymore. Before this, it rejected only null values. Moved setState inside the if statement.