### PR TITLE
Fix/ecocounter-date-fix

### DIFF
--- a/src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
+++ b/src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable no-nested-ternary */
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
@@ -169,7 +170,7 @@ const EcoCounterContent = ({ classes, stationId, stationName }) => {
 
   // Reset selectedDate value when the new popup is opened.
   useEffect(() => {
-    setSelectedDate(currentDate);
+    setSelectedDate(moment().clone().add(-1, 'days'));
   }, [stationId]);
 
   useEffect(() => {


### PR DESCRIPTION
# Fix to incorrect date value

## Breakdown:
Eco-counter now displays yesterday (latest full day of data) instead of today inside the header in popup.

### Change date value
1. src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
    * When popup view was opened selectedDate value was accidentally changed from initial value (yesterday) into the current date. Now it sets correct value into state.