### PR TITLE
Fix/refactor-env-use

### DIFF
--- a/src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
+++ b/src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
@@ -35,7 +35,7 @@ const EcoCounterContent = ({ classes, stationId, stationName }) => {
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState(moment().clone().add(-1, 'days'));
 
-  const apiUrl = window.nodeEnvSettings.ECOCOUNTER_API;
+  const apiUrl = window.nodeEnvSettings.MOBILITY_PLATFORM_API;
 
   const intl = useIntl();
 
@@ -163,7 +163,7 @@ const EcoCounterContent = ({ classes, stationId, stationName }) => {
   // API returns empty data if start_week_number parameter is higher number than end_week_number.
   // This will set it to 1 so that weekly graph in January won't be empty.
   const checkWeekNumber = () => {
-    if (selectedWeekStart === 53) {
+    if (selectedWeekStart > selectedWeekEnd) {
       selectedWeekStart = 1;
     }
   };

--- a/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
+++ b/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
@@ -10,7 +10,7 @@ const EcoCounterMarkers = ({ classes }) => {
 
   const { openMobilityPlatform, showEcoCounter } = useContext(MobilityPlatformContext);
 
-  const apiUrl = window.nodeEnvSettings.ECOCOUNTER_API;
+  const apiUrl = window.nodeEnvSettings.MOBILITY_PLATFORM_API;
 
   const { Marker, Popup } = global.rL;
   const { icon } = global.L;

--- a/src/components/EcoCounter/EcoCounterRequests/ecoCounterRequests.js
+++ b/src/components/EcoCounter/EcoCounterRequests/ecoCounterRequests.js
@@ -4,7 +4,7 @@
 
 export const fetchEcoCounterStations = async (apiUrl, setStations) => {
   try {
-    const response = await fetch(`${apiUrl}/stations/`);
+    const response = await fetch(`${apiUrl}/eco-counter/stations/`);
     const jsonData = await response.json();
     setStations(jsonData.results);
   } catch (err) {
@@ -15,7 +15,7 @@ export const fetchEcoCounterStations = async (apiUrl, setStations) => {
 export const fetchInitialHourData = async (apiUrl, day, stationId, setHourData) => {
   try {
     const response = await fetch(
-      `${apiUrl}/hour_data/get_hour_data?date=${day}&station_id=${stationId}`,
+      `${apiUrl}/eco-counter/hour_data/get_hour_data?date=${day}&station_id=${stationId}`,
     );
     const jsonData = await response.json();
     setHourData(jsonData);
@@ -33,7 +33,7 @@ export const fetchInitialDayDatas = async (
 ) => {
   try {
     const response = await fetch(
-      `${apiUrl}/day_data/get_day_datas?start_date=${startDate}&end_date=${endDate}&station_id=${id}`,
+      `${apiUrl}/eco-counter/day_data/get_day_datas?start_date=${startDate}&end_date=${endDate}&station_id=${id}`,
     );
     const jsonData = await response.json();
     setDayData(jsonData);
@@ -52,7 +52,7 @@ export const fetchInitialWeekDatas = async (
 ) => {
   try {
     const response = await fetch(
-      `${apiUrl}/week_data/get_week_datas?year_number=${year}&start_week_number=${startWeek}&end_week_number=${endWeek}&station_id=${id}`,
+      `${apiUrl}/eco-counter/week_data/get_week_datas?year_number=${year}&start_week_number=${startWeek}&end_week_number=${endWeek}&station_id=${id}`,
     );
     const jsonData = await response.json();
     setWeekData(jsonData);
@@ -71,7 +71,7 @@ export const fetchInitialMonthDatas = async (
 ) => {
   try {
     const response = await fetch(
-      `${apiUrl}/month_data/get_month_datas?year_number=${yearNumber}&start_month_number=${startMonth}&end_month_number=${endMonth}&station_id=${id}`,
+      `${apiUrl}/eco-counter/month_data/get_month_datas?year_number=${yearNumber}&start_month_number=${startMonth}&end_month_number=${endMonth}&station_id=${id}`,
     );
     const jsonData = await response.json();
     setMonthData(jsonData);

--- a/src/components/MobilityPlatform/BicycleStands/BicycleStands.js
+++ b/src/components/MobilityPlatform/BicycleStands/BicycleStands.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useContext } from 'react';
 import { PropTypes } from 'prop-types';
 import MobilityPlatformContext from '../../../context/MobilityPlatformContext';
 import BicycleStandContent from '../BicycleStandContent';
-import { fetchBicycleStandsData } from '../mobilityPlatformRequests/mobilityPlatformRequests';
+import { fetchMobilityMapData } from '../mobilityPlatformRequests/mobilityPlatformRequests';
 import bicycleStandIcon from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_bicycle-stand.svg';
 
 const BicycleStands = ({ classes }) => {
@@ -23,7 +23,7 @@ const BicycleStands = ({ classes }) => {
 
   useEffect(() => {
     if (openMobilityPlatform) {
-      fetchBicycleStandsData(apiUrl, setBicycleStands);
+      fetchMobilityMapData(apiUrl, 'BIS', 100, setBicycleStands);
     }
   }, [openMobilityPlatform, setBicycleStands]);
 

--- a/src/components/MobilityPlatform/ChargerStationMarkers/ChargerStationMarkers.js
+++ b/src/components/MobilityPlatform/ChargerStationMarkers/ChargerStationMarkers.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useContext } from 'react';
 import { PropTypes } from 'prop-types';
 import MobilityPlatformContext from '../../../context/MobilityPlatformContext';
 import ChargerStationContent from '../ChargerStationContent';
-import { fetchCGSStationsData } from '../mobilityPlatformRequests/mobilityPlatformRequests';
+import { fetchMobilityMapData } from '../mobilityPlatformRequests/mobilityPlatformRequests';
 import chargerIcon from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_charging_station.svg';
 
 const ChargerStationMarkers = ({ classes }) => {
@@ -22,7 +22,7 @@ const ChargerStationMarkers = ({ classes }) => {
 
   useEffect(() => {
     if (openMobilityPlatform) {
-      fetchCGSStationsData(apiUrl, setChargerStations);
+      fetchMobilityMapData(apiUrl, 'CGS', 150, setChargerStations);
     }
   }, [openMobilityPlatform, setChargerStations]);
 

--- a/src/components/MobilityPlatform/GasFillingStationMarkers/GasFillingStationMarkers.js
+++ b/src/components/MobilityPlatform/GasFillingStationMarkers/GasFillingStationMarkers.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useContext } from 'react';
 import { PropTypes } from 'prop-types';
 import MobilityPlatformContext from '../../../context/MobilityPlatformContext';
 import ChargerStationContent from '../ChargerStationContent';
-import { fetchGFSStationsData } from '../mobilityPlatformRequests/mobilityPlatformRequests';
+import { fetchMobilityMapData } from '../mobilityPlatformRequests/mobilityPlatformRequests';
 import gasFillingIcon from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_gas_station.svg';
 
 const GasFillingStationMarkers = ({ classes }) => {
@@ -22,7 +22,7 @@ const GasFillingStationMarkers = ({ classes }) => {
 
   useEffect(() => {
     if (openMobilityPlatform) {
-      fetchGFSStationsData(apiUrl, setGasFillingStations);
+      fetchMobilityMapData(apiUrl, 'GFS', 10, setGasFillingStations);
     }
   }, [openMobilityPlatform, setGasFillingStations]);
 

--- a/src/components/MobilityPlatform/mobilityPlatformRequests/mobilityPlatformRequests.js
+++ b/src/components/MobilityPlatform/mobilityPlatformRequests/mobilityPlatformRequests.js
@@ -1,30 +1,11 @@
 /* eslint-disable max-len */
 /* eslint-disable import/prefer-default-export */
+
 // Functions to make requests to the API
 
-export const fetchCGSStationsData = async (apiUrl, setStations) => {
+export const fetchMobilityMapData = async (apiUrl, type, pageSize, setStations) => {
   try {
-    const response = await fetch(`${apiUrl}/mobile_units?type_name=CGS&page_size=150&srid=4326`);
-    const jsonData = await response.json();
-    setStations(jsonData.results);
-  } catch (err) {
-    console.warn(err.message);
-  }
-};
-
-export const fetchGFSStationsData = async (apiUrl, setStations) => {
-  try {
-    const response = await fetch(`${apiUrl}/mobile_units?type_name=GFS&page_size=10&srid=4326`);
-    const jsonData = await response.json();
-    setStations(jsonData.results);
-  } catch (err) {
-    console.warn(err.message);
-  }
-};
-
-export const fetchBicycleStandsData = async (apiUrl, setStations) => {
-  try {
-    const response = await fetch(`${apiUrl}/mobile_units?type_name=BIS&page_size=100&srid=4326`);
+    const response = await fetch(`${apiUrl}/mobility_data/mobile_units?type_name=${type}&page_size=${pageSize}&srid=4326`);
     const jsonData = await response.json();
     setStations(jsonData.results);
   } catch (err) {
@@ -34,7 +15,7 @@ export const fetchBicycleStandsData = async (apiUrl, setStations) => {
 
 export const fetchCultureRoutesGroup = async (apiUrl, setStations) => {
   try {
-    const response = await fetch(`${apiUrl}/mobile_unit_groups/`);
+    const response = await fetch(`${apiUrl}/mobility_data/mobile_unit_groups/`);
     const jsonData = await response.json();
     setStations(jsonData.results);
   } catch (err) {
@@ -44,7 +25,7 @@ export const fetchCultureRoutesGroup = async (apiUrl, setStations) => {
 
 export const fetchCultureRoutesData = async (apiUrl, type, size, setStations) => {
   try {
-    const response = await fetch(`${apiUrl}/mobile_units?type_name=${type}&page_size=${size}&latlon=true&srid=4326`);
+    const response = await fetch(`${apiUrl}/mobility_data/mobile_units?type_name=${type}&page_size=${size}&latlon=true&srid=4326`);
     const jsonData = await response.json();
     setStations(jsonData.results);
   } catch (err) {


### PR DESCRIPTION
# Refactor env variable use

## Breakdown:
Refactors fetch functions to use only one env variable.

### Update api url variable
1. src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
    * Updates apiUrl variable. Also fixes small bug in the checkWeekNumber -function.
	
2.  src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
     * Updates apiUrl variable.

### Refactor fetch -functions
1. src/components/EcoCounter/EcoCounterRequests/ecoCounterRequests.js
    * Update API endpoints that are used in fetch -functions.

2. src/components/MobilityPlatform/mobilityPlatformRequests/mobilityPlatformRequests.js
    * Update API endpoints that are used in fetch -functions. Replace multiple similar fetch -functions with one. Add type and page size into parameters.

### Utilize refactored fetch -function
1. src/components/MobilityPlatform/BicycleStands/BicycleStands.js
    * Now utilizes fetchMobilityMapData -function.

2. src/components/MobilityPlatform/ChargerStationMarkers/ChargerStationMarkers.js
    * Now utilizes fetchMobilityMapData -function.

3. src/components/MobilityPlatform/GasFillingStationMarkers/GasFillingStationMarkers.js
    * Now utilizes fetchMobilityMapData -function.