### PR TITLE
Feature/search-language-param

### DIFF
--- a/src/components/SearchBar/components/SuggestionBox/SuggestionBox.js
+++ b/src/components/SearchBar/components/SuggestionBox/SuggestionBox.js
@@ -44,6 +44,7 @@ const SuggestionBox = (props) => {
   const [suggestionError, setSuggestionError] = useState(false);
   // Query word on which suggestion list is based
   const [suggestionQuery, setSuggestionQuery] = useState(null);
+  const locale = useSelector(state => state.user.locale);
 
   const getAddressNavigatorParams = useNavigationParams();
   const dispatch = useDispatch();
@@ -112,7 +113,7 @@ const SuggestionBox = (props) => {
       }
       fetchController.current = new AbortController();
 
-      dispatch(createSuggestions(query, fetchController.current, getLocaleText, citySettings))
+      dispatch(createSuggestions(query, fetchController.current, getLocaleText, citySettings, locale))
         .then((data) => {
           if (data === 'error') {
             return;

--- a/src/components/SearchBar/createSuggestions.js
+++ b/src/components/SearchBar/createSuggestions.js
@@ -2,7 +2,7 @@
 
 import ServiceMapAPI from '../../utils/newFetch/ServiceMapAPI';
 
-const createSuggestions = (query, abortController, getLocaleText, citySettings) => async () => {
+const createSuggestions = (query, abortController, getLocaleText, citySettings, locale) => async () => {
   const smAPI = new ServiceMapAPI();
   smAPI.setAbortController(abortController);
 
@@ -12,7 +12,8 @@ const createSuggestions = (query, abortController, getLocaleText, citySettings) 
     unit_limit: 5,
     service_limit: 2,
     address_limit: 1,
-    municipality: citySettings.join(','),
+    language: locale,
+    municipality: citySettings && citySettings.length > 0 ? citySettings.join(',') : 'turku',
   };
 
   const results = await smAPI.search(query, additionalOptions);

--- a/src/utils/newFetch/ServiceMapAPI.js
+++ b/src/utils/newFetch/ServiceMapAPI.js
@@ -19,10 +19,10 @@ export default class ServiceMapAPI extends HttpClient {
     const options = { // TODO: adjust these values for best results and performance
       q: query,
       page_size: 200,
-      sql_query_limit: 1000,
-      unit_limit: 500,
-      service_limit: 250,
-      address_limit: 250,
+      sql_query_limit: 2000,
+      unit_limit: 1000,
+      service_limit: 500,
+      address_limit: 500,
       ...additionalOptions,
     };
 


### PR DESCRIPTION
# Add language parameter into search suggestions

## Add language query parameter to improve and localize search suggestions. Also add default value for municipality parameter if user has not selected cities from settings. This will also improve search suggestions. Adjust search limit values.

### Trello card 74

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Language param and default value for municipality
 1. src/components/SearchBar/components/SuggestionBox/SuggestionBox.js
     * Get current locale value from (Redux) state and place it into parameters of the createSuggestions -function.
   
 2. src/components/SearchBar/createSuggestions.js
     * Now expects locale value parameter. Checks if citySettings is an empty array or not. If it's empty then add default value for municipality query param to show better suggestions.
       
#### Adjust main search limit values
 1. src/utils/newFetch/ServiceMapAPI.js
     * Allow more SQL queries for main search. Increase unit, service and address limits.
