### PR TITLE
Fix/sort-routes-fix

### DIFF
--- a/src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
+++ b/src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
@@ -29,7 +29,7 @@ const CultureRouteUnits = ({ classes, intl, cultureRoute }) => {
 
   useEffect(() => {
     if (openMobilityPlatform) {
-      fetchCultureRoutesData(apiUrl, 'CRU', 150, setCultureRouteUnits);
+      fetchCultureRoutesData(apiUrl, 'CRU', 200, setCultureRouteUnits);
     }
   }, [openMobilityPlatform, setCultureRouteUnits]);
 

--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -397,8 +397,8 @@ const MobilitySettingsView = ({ classes, intl }) => {
           </FormGroup>
         </FormControl>
       </div>
-      {showEcoCounter ? <InfoTextBox infoText="mobilityPlatform.info.ecoCounter" /> : null}
       {showBicycleStands ? <InfoTextBox infoText="mobilityPlatform.info.bicycleStands" /> : null}
+      {showEcoCounter ? <InfoTextBox infoText="mobilityPlatform.info.ecoCounter" /> : null}
     </div>
   );
 };

--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -129,7 +129,10 @@ const MobilitySettingsView = ({ classes, intl }) => {
       sv: 'name_sv',
     };
     if (bicycleRouteList) {
-      bicycleRouteList.sort((a, b) => a[objKeys[currentLocale]].localeCompare(b[objKeys[currentLocale]]));
+      bicycleRouteList.sort((a, b) => a[objKeys[currentLocale]].localeCompare(b[objKeys[currentLocale]], undefined, {
+        numeric: true,
+        sensivity: 'base',
+      }));
     }
   }, [bicycleRouteList, currentLocale]);
 
@@ -252,7 +255,7 @@ const MobilitySettingsView = ({ classes, intl }) => {
           }}
           onChange={onChangeValue}
         />
-)}
+      )}
       className={classes.formLabel}
     />
   );
@@ -294,7 +297,8 @@ const MobilitySettingsView = ({ classes, intl }) => {
     return null;
   };
 
-  const renderBicycleRoutes = (inputData, activeIdx) => inputData && inputData.length > 0
+  const renderBicycleRoutes = (inputData, activeIdx) => inputData
+    && inputData.length > 0
     && inputData.map((item, i) => (
       <Button
         key={item.id}
@@ -302,13 +306,17 @@ const MobilitySettingsView = ({ classes, intl }) => {
         className={i === activeIdx ? classes.listButtonActive : classes.listButton}
         onClick={() => setBicycleRouteState(i, item.name_fi)}
       >
-        <Typography variant="body2" aria-label={selectRouteName(currentLocale, item.name_fi, item.name_en, item.name_sv)}>
+        <Typography
+          variant="body2"
+          aria-label={selectRouteName(currentLocale, item.name_fi, item.name_en, item.name_sv)}
+        >
           {selectRouteName(currentLocale, item.name_fi, item.name_en, item.name_sv)}
         </Typography>
       </Button>
     ));
 
-  const renderCultureRoutes = (inputData, activeIdx) => inputData && inputData.length > 0
+  const renderCultureRoutes = (inputData, activeIdx) => inputData
+    && inputData.length > 0
     && inputData.map((item, i) => (
       <Button
         key={item.id}


### PR DESCRIPTION
# Few bugfixes

## Fixes few bugs that were found, for example fixes instances where strings containing numbers 10 - 19 were displayed before numbers 2 - 9 when rendering bicycle route names. Also fetches remaining units for culture routes.

### Issues mentioned on rows 17 and 19 in Excel file.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Improve sort and localeCompare
 1. src/views/MobilitySettingsView/MobilitySettingsView.js
     * Improves localeCompare by setting numeric to true. Now it renders strings that include numbers 2 - 9 before numbers like 10.
     
#### Change text order. Increase page_size value.
 1. src/views/MobilitySettingsView/MobilitySettingsView.js
     * Change order of texts.
   
 2. src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
     * Increase page_size so that all units are fetched.
