### PR TITLE
Bugfix/crash-after-search

### DIFF
--- a/src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
+++ b/src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
@@ -430,11 +430,17 @@ const EcoCounterContent = ({
     } else setUserTypesList(bicycleOnly);
   }, [stationId]);
 
+  const renderStationName = (input) => {
+    if (input === 'Teatteri ranta') {
+      return 'Teatteriranta';
+    } return input;
+  };
+
   return (
     <>
       <div className={classes.ecoCounterHeader}>
         <Typography component="h4" className={classes.headerSubtitle}>
-          {stationName}
+          {renderStationName(stationName)}
         </Typography>
         <div className={classes.headerDate}>
           {!isDatePickerOpen ? (

--- a/src/components/EcoCounter/EcoCounterContent/styles.js
+++ b/src/components/EcoCounter/EcoCounterContent/styles.js
@@ -39,7 +39,7 @@ const styles = {
     marginBottom: '0.75rem',
     alignItems: 'flex-end',
     borderBottom: '2px solid gray',
-    width: '97%',
+    width: '95%',
   },
   headerSubtitle: {
     marginBlockStart: '1rem',

--- a/src/views/UnitView/components/Description/Description.js
+++ b/src/views/UnitView/components/Description/Description.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Typography, Link } from '@material-ui/core';
@@ -10,21 +10,12 @@ import useLocaleText from '../../../../utils/useLocaleText';
 const Description = ({ unit, classes }) => {
   const getLocaleText = useLocaleText();
 
-  // Custom state for this, because bicycle stand description value evaluates to false and extra fields won't render
-  const [isBicycleStand, setIsBicycleStand] = useState(false);
-
   const additionalInfo = [
     ...unitSectionFilter(unit.connections, 'OTHER_INFO'),
     ...unitSectionFilter(unit.connections, 'TOPICAL'),
   ];
 
-  useEffect(() => {
-    if (unit.services[0].id === 40000) {
-      setIsBicycleStand(true);
-    }
-  }, [unit]);
-
-  if (unit.description || additionalInfo.length || isBicycleStand) {
+  if (unit.description || additionalInfo.length || unit.services[0].id === 40000) {
     return (
       <div>
         {/* Description */}


### PR DESCRIPTION
# Fix to crash after certain search query.

## Fixes bug that caused a crash after searching "perusopetus venäjä". It was not related to search. It was an undefined value that caused unit view to crash. Will display measurement point "Teatteri ranta" as "Teatteriranta".

### Rows 15 and 21 in Excel file.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Fix to crash. Display station name without space.
 1. src/views/UnitView/components/Description/Description.js
     * Streamlined if statement that checks if unit view is bicycle stand. Checking it inside useEffect caused the error.
   
 2. src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
     * Checks if stationName is Teatteri ranta in the source data and will display 'Teatteriranta'.
    
 3. src/components/EcoCounter/EcoCounterContent/styles.js
     * Reduce header width by 2% so that it won't overlap with corner element.
