### PR TITLE
Display mobility map only on the default layout

### DIFF
--- a/src/layouts/DefaultLayout.js
+++ b/src/layouts/DefaultLayout.js
@@ -228,6 +228,7 @@ const DefaultLayout = (props) => {
                     sidebarHidden={sidebarHidden}
                     toggleSidebar={toggleSidebar}
                     isMobile={!!isMobile}
+                    showMobilityPlatform
                   />
                 </MobilityPlatformProvider>
               </div>

--- a/src/layouts/EmbedLayout.js
+++ b/src/layouts/EmbedLayout.js
@@ -128,7 +128,7 @@ const EmbedLayout = ({ intl }) => {
         </div>
         <Typography variant="srOnly">{intl.formatMessage({ id: 'map.ariaLabel' })}</Typography>
         <div aria-hidden tabIndex="-1" style={styles.map}>
-          <MapView />
+          <MapView showMobilityPlatform={false} />
         </div>
       </div>
     </>

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -67,6 +67,7 @@ const MapView = (props) => {
     measuringMode,
     toggleSidebar,
     sidebarHidden,
+    showMobilityPlatform,
   } = props;
 
   // State
@@ -422,7 +423,7 @@ const MapView = (props) => {
             <PanControl key="panControl" />
           </CustomControls>
           <CoordinateMarker position={getCoordinatesFromUrl()} />
-          <MobilityPlatformMapView />
+          {showMobilityPlatform ? <MobilityPlatformMapView /> : null}
         </MapContainer>
       </>
     );
@@ -464,6 +465,7 @@ MapView.propTypes = {
   measuringMode: PropTypes.bool.isRequired,
   toggleSidebar: PropTypes.func,
   sidebarHidden: PropTypes.bool,
+  showMobilityPlatform: PropTypes.bool,
 };
 
 MapView.defaultProps = {
@@ -482,4 +484,5 @@ MapView.defaultProps = {
   toggleSidebar: null,
   sidebarHidden: false,
   userLocation: null,
+  showMobilityPlatform: true,
 };


### PR DESCRIPTION
# Fix to embed layout error

## Map wasn't rendered correctly inside the embed layout (embedder tool) because mobility map is not yet fully integrated into it. Now renders the default map (without the mobility map) inside the embed layout. At the moment only the default layout contains mobility map functionality.

### Trello card 106

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Display mobility map only on the default layout
 1. src/views/MapView/MapView.js
     * Add prop to toggle visibility of mobility map inside the mapView.
   
 2. src/layouts/DefaultLayout.js
     * Set true to said showMobilityPlatform -prop.
    
 3. src/layouts/EmbedLayout.js
     * Set false to said showMobilityPlatform -prop.