### PR TITLE
Feature/embed-bbox-option

### DIFF
--- a/src/components/ToolMenu/ToolMenu.js
+++ b/src/components/ToolMenu/ToolMenu.js
@@ -59,9 +59,6 @@ const ToolMenu = ({
 
     const uri = URI(window.location);
     const search = uri.search(true);
-    if (!search.bbox) {
-      search.bbox = mapUtility.getBbox();
-    }
     uri.search(search);
     let searchParams = uri.search();
 
@@ -99,7 +96,7 @@ const ToolMenu = ({
     },
     {
       key: 'printTool',
-      text: intl.formatMessage({ id: 'tool.print'}),
+      text: intl.formatMessage({ id: 'tool.print' }),
       icon: <Print className={classes.smIcon} />,
       onClick: () => {
         if (typeof togglePrintView === 'function') {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -158,6 +158,7 @@ const translations = {
   'embedder.options.title': 'Show on the map',
   'embedder.options.label.units': 'Show service points',
   'embedder.options.label.transit': 'Show public transport stops (Zoom in the map to see the stops)',
+  'embedder.options.label.bbox': 'Limit the embedded map to the area in the preview window',
   'embedder.service.title': 'Services',
   'embedder.service.aria.label': 'Choose services to be shown',
   'embedder.service.none': 'Map is shown without service points',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -157,6 +157,7 @@ const translations = {
   'embedder.options.title': 'Näytä kartalla',
   'embedder.options.label.units': 'Näytä toimipisteet',
   'embedder.options.label.transit': 'Näytä joukkoliikenteen pysäkit (Tarkenna karttaa lähietäisyydelle, jotta joukkoliikennepysäkit näkyvät)',
+  'embedder.options.label.bbox': 'Rajaa upotuskartta esikatseluikkunassa näkyvään alueeseen',
   'embedder.preview.title': 'Kartan esikatselu',
   'embedder.service.title': 'Palvelut',
   'embedder.service.aria.label': 'Valitse näytettävät palvelut',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -157,6 +157,7 @@ const translations = {
   'embedder.options.title': 'Visa på kartan',
   'embedder.options.label.units': 'Visa verksamhetsställen',
   'embedder.options.label.transit': 'Visa kollektivtrafikens hållplatser (Zooma in kartan för att se hållplatserna)',
+  'embedder.options.label.bbox': 'Begränsa den inbäddade kartan till området i förhandsgranskningsfönstret',
   'embedder.preview.title': 'Map preview',
   'embedder.service.title': 'Tjänster',
   'embedder.service.aria.label': 'Välj tjänsterna som visas',

--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { Typography } from '@material-ui/core';
 import { Map } from '@material-ui/icons';
-import { focusDistrict, focusDistricts } from '../MapView/utils/mapActions';
+import { focusDistrict, focusDistricts, useMapFocusDisabled } from '../MapView/utils/mapActions';
 import TabLists from '../../components/TabLists';
 import GeographicalTab from './components/GeographicalTab';
 import { parseSearchParams, formAddressString } from '../../utils';
@@ -58,6 +58,7 @@ const AreaView = ({
   const selectedArea = searchParams.selected;
   // Get area parameter without year data
   const selectedAreaType = selectedArea?.split(/([0-9]+)/)[0];
+  const mapFocusDisabled = useMapFocusDisabled();
 
   const getInitialOpenItems = () => {
     if (selectedAreaType) {
@@ -75,7 +76,7 @@ const AreaView = ({
   const [focusTo, setFocusTo] = useState(null);
 
   const focusMapToDistrict = (district) => {
-    if (map && district?.boundary) {
+    if (!mapFocusDisabled && map && district?.boundary) {
       focusDistrict(map, district.boundary.coordinates);
     }
   };
@@ -154,7 +155,7 @@ const AreaView = ({
 
   useEffect(() => {
     // If pending district focus, focus to districts when distitct data is loaded
-    if (focusTo && selectedDistrictData.length) {
+    if (!mapFocusDisabled && focusTo && selectedDistrictData.length) {
       if (focusTo === 'districts') {
         if (selectedDistrictGeometry) {
           setFocusTo(null);
@@ -173,7 +174,7 @@ const AreaView = ({
   }, [selectedDistrictData, focusTo]);
 
   useEffect(() => {
-    if (map && !focusTo && !localAddressData.length && selectedDistrictGeometry) {
+    if (!mapFocusDisabled && map && !focusTo && !localAddressData.length && selectedDistrictGeometry) {
       focusDistricts(map, selectedDistrictData);
     }
   }, [selectedDistrictGeometry]);
@@ -205,7 +206,7 @@ const AreaView = ({
       }
 
       // Set selected geographical districts from url parameters and handle map focus
-      if (searchParams.districts) {
+      if (searchParams.districts && !mapFocusDisabled) {
         setSelectedSubdistricts(searchParams.districts.split(','));
         setFocusTo('subdistricts');
       }
@@ -227,7 +228,7 @@ const AreaView = ({
     } else if (mapState) { // Returning to page, without url parameters
       // Returns map to the previous spot
       const { center, zoom } = mapState;
-      if (map && center && zoom) map.setView(center, zoom);
+      if (!map && center && zoom) map.setView(center, zoom);
     }
   }, []);
 

--- a/src/views/EmbedderView/components/EmbedHTML.js
+++ b/src/views/EmbedderView/components/EmbedHTML.js
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Paper, TextField, Typography } from '@material-ui/core';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { getEmbedURL } from '../utils/utils';
+
+
+/**
+   * Renders embed HTMl based on options
+*/
+const EmbedHTML = ({
+  classes, createEmbedHTML, url, setBoundsRef, restrictBounds,
+}) => {
+  const intl = useIntl();
+  const [bbox, setBbox] = useState(null);
+
+  const embedUrl = getEmbedURL(url, { bbox: restrictBounds ? bbox : null });
+
+  const handleEventMessage = (event) => {
+    // Update bbox on map move
+    if (event.data.bbox) {
+      setBoundsRef(event.data.bbox);
+      setBbox(event.data.bbox);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('message', handleEventMessage);
+    // Run component unmount cleanup
+    return () => {
+      window.removeEventListener('message', handleEventMessage);
+    };
+  }, []);
+
+  const htmlText = createEmbedHTML(embedUrl);
+  const textFieldClass = `${classes.textField} ${classes.marginBottom}`;
+
+  return (
+    <Paper className={classes.formContainerPaper}>
+      {
+          /* Embed address */
+        }
+      <Typography
+        align="left"
+        className={classes.marginBottom}
+        variant="h5"
+        component="h2"
+      >
+        <FormattedMessage id="embedder.url.title" />
+      </Typography>
+      <TextField
+        id="embed-address"
+        className={textFieldClass}
+        value={embedUrl}
+        margin="normal"
+        variant="outlined"
+        inputProps={{ 'aria-label': intl.formatMessage({ id: 'embedder.url.title' }) }}
+      />
+      {
+          /* Embed HTML code */
+        }
+      <Typography
+        align="left"
+        className={classes.marginBottom}
+        variant="h5"
+        component="h2"
+      >
+        <FormattedMessage id="embedder.code.title" />
+      </Typography>
+      <pre className={classes.pre}>
+        { htmlText }
+      </pre>
+    </Paper>
+  );
+};
+
+EmbedHTML.propTypes = {
+  classes: PropTypes.objectOf(PropTypes.any).isRequired,
+  createEmbedHTML: PropTypes.func.isRequired,
+  url: PropTypes.string.isRequired,
+  setBoundsRef: PropTypes.func.isRequired,
+  restrictBounds: PropTypes.bool.isRequired,
+};
+
+export default EmbedHTML;

--- a/src/views/EmbedderView/components/IFramePreview.js
+++ b/src/views/EmbedderView/components/IFramePreview.js
@@ -14,6 +14,7 @@ const IFramePreview = ({
   title,
   titleComponent,
   widthMode,
+  renderBoundsControl,
 }) => {
   if (!embedUrl) {
     return null;
@@ -81,6 +82,7 @@ const IFramePreview = ({
       >
         <FormattedMessage id="embedder.preview.title" />
       </Typography>
+      {renderBoundsControl()}
       <div className={classes.iframeContainer} style={{ width: '100%' }}>
         {
           element
@@ -105,6 +107,7 @@ IFramePreview.propTypes = {
   titleComponent: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']).isRequired,
   ratioHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   widthMode: PropTypes.string.isRequired,
+  renderBoundsControl: PropTypes.func.isRequired,
 };
 
 IFramePreview.defaultProps = {

--- a/src/views/EmbedderView/utils/utils.js
+++ b/src/views/EmbedderView/utils/utils.js
@@ -9,14 +9,14 @@ export const getEmbedURL = (url, params = {}) => {
   const segment = uri.segment();
   const data = uri.search(true); // Get data object of search parameters
   const cityObj = params.city;
-  const cities = Object.keys(cityObj).reduce((acc, current) => {
+  const cities = cityObj ? Object.keys(cityObj).reduce((acc, current) => {
     if (Object.prototype.hasOwnProperty.call(cityObj, current)) {
       if (cityObj[current]) {
         acc.push(current);
       }
     }
     return acc;
-  }, []);
+  }, []) : [];
 
   if (params.map && params.map !== 'servicemap') {
     data.map = params.map;
@@ -35,6 +35,9 @@ export const getEmbedURL = (url, params = {}) => {
   }
   if (params.showUnits === false) {
     data.units = 'none';
+  }
+  if (params.bbox) {
+    data.bbox = params.bbox;
   }
 
   uri.search(data);

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -5,9 +5,10 @@ import { withRouter } from 'react-router-dom';
 import { Tooltip as MUITooltip, ButtonBase } from '@material-ui/core';
 import { MyLocation, LocationDisabled } from '@material-ui/icons';
 import { useSelector } from 'react-redux';
+import { useMapEvents } from 'react-leaflet';
 import { mapOptions } from './config/mapConfig';
 import CreateMap from './utils/createMap';
-import { focusToPosition } from './utils/mapActions';
+import { focusToPosition, getBoundsFromBbox } from './utils/mapActions';
 import Districts from './components/Districts';
 import TransitStops from './components/TransitStops';
 import AddressPopup from './components/AddressPopup';
@@ -39,6 +40,20 @@ if (global.window) {
   require('leaflet.markercluster');
   global.rL = require('react-leaflet');
 }
+
+const EmbeddedActions = () => {
+  const embedded = isEmbed();
+  const map = useMapEvents({
+    moveend() {
+      if (embedded) {
+        const bounds = map.getBounds();
+        window.parent.postMessage({ bbox: `${bounds.getSouth()},${bounds.getWest()},${bounds.getNorth()},${bounds.getEast()}` });
+      }
+    },
+  });
+
+  return null;
+};
 
 const MapView = (props) => {
   const {
@@ -308,6 +323,7 @@ const MapView = (props) => {
       id: !userLocation ? 'location.notAllowed' : 'location.center',
     });
     const eventSearch = parseSearchParams(location.search).events;
+    const defaultBounds = parseSearchParams(location.search).bbox;
 
     return (
       <>
@@ -318,9 +334,10 @@ const MapView = (props) => {
           className={`${classes.map} ${embedded ? classes.mapNoSidebar : ''} `}
           key={mapObject.options.name}
           zoomControl={false}
+          bounds={getBoundsFromBbox(defaultBounds?.split(','))}
           doubleClickZoom={false}
           crs={mapObject.crs}
-          center={center}
+          center={!defaultBounds ? center : null}
           zoom={zoom}
           minZoom={mapObject.options.minZoom}
           maxZoom={mapObject.options.maxZoom}
@@ -423,6 +440,7 @@ const MapView = (props) => {
             <PanControl key="panControl" />
           </CustomControls>
           <CoordinateMarker position={getCoordinatesFromUrl()} />
+          <EmbeddedActions />
           {showMobilityPlatform ? <MobilityPlatformMapView /> : null}
         </MapContainer>
       </>

--- a/src/views/MapView/utils/mapActions.js
+++ b/src/views/MapView/utils/mapActions.js
@@ -81,10 +81,7 @@ const fitBbox = (map, bbox) => {
   if (!map || !bbox || bbox.length !== 4) {
     return;
   }
-  const L = require('leaflet');
-  const sw = L.latLng(bbox.slice(0, 2));
-  const ne = L.latLng(bbox.slice(2, 4));
-  const bounds = L.latLngBounds(sw, ne);
+  const bounds = getBoundsFromBbox(bbox);
   map.fitBounds(bounds);
 };
 


### PR DESCRIPTION
# New option for the embedder tool to set embedded map bounds.

## Add a new option for the embedder tool to set embedded map bounds by moving the map preview. Feature taken from Helsinki servicemap. Few lines of these changes were unintentionally brought in when other features were updated and that pushed bbox values into the url of the embedder. Bringing in rest of changes will fix that.

### Trello card 107

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Add new embedder bbox functionality
 1. src/views/EmbedderView/EmbedderView.js
     * Add checkbox for the option. Update mapbox with getGounds -functionality. Update iFrame preview element.
   
 2. src/views/EmbedderView/components/EmbedHTML.js
     * Renders HTML inside iFrame element based on options like selected municipalities and bbox.
    
 3. src/views/EmbedderView/components/IFramePreview.js
     * Add controls for rendering bounds.

 4. src/views/EmbedderView/utils/utils.js
     * Add bbox params and update and update cities variable.
   
 5. src/views/MapView/MapView.js
     * Utilize map actions to get bounds.
    
 6. src/views/MapView/utils/mapActions.js
      * Call new function.
 
7. src/components/ToolMenu/ToolMenu.js
     * Remove getBbox from here.

 8. src/views/AreaView/AreaView.js
     * Call new function from map actions.
   
 9. src/i18n/en.js & src/i18n/fi.js & src/i18n/sv.js
     * Add translations
   