### PR TITLE
fix/ecocounter-mobile-styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -84,6 +84,32 @@
   .rental-cars-popup > .leaflet-popup-content-wrapper > .leaflet-popup-content {
     width: 370px !important;
   }
+
+  .ecocounter-popup {
+    width: 380px;
+  }
+
+  .ecocounter-popup > .leaflet-popup-content-wrapper > .leaflet-popup-content {
+    width: 370px !important;
+  }
+}
+
+@media (max-width: 380px) {
+  .rental-cars-popup {
+    width: 345px;
+  }
+
+  .rental-cars-popup > .leaflet-popup-content-wrapper > .leaflet-popup-content {
+    width: 340px !important;
+  }
+
+  .ecocounter-popup {
+    width: 355px;
+  }
+
+  .ecocounter-popup > .leaflet-popup-content-wrapper > .leaflet-popup-content {
+    width: 350px !important;
+  }
 }
 
 /* React Dates */


### PR DESCRIPTION
# Adjust width for mobile screens

## When on mobile,  reduce width of 2 modals that are wider that default.

### Card 120

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Adjust width for mobile screens
 1. src/App.css
     * Add a new breakpoint to properly fit wider modals into mobile screens.
