### PR TITLE
Fix/search-update-query-param

### DIFF
--- a/src/components/SearchBar/createSuggestions.js
+++ b/src/components/SearchBar/createSuggestions.js
@@ -1,4 +1,5 @@
 import ServiceMapAPI from '../../utils/newFetch/ServiceMapAPI';
+import config from '../../../config';
 
 const createSuggestions = (query, abortController, getLocaleText, citySettings, locale) => async () => {
   const smAPI = new ServiceMapAPI();
@@ -11,7 +12,7 @@ const createSuggestions = (query, abortController, getLocaleText, citySettings, 
     service_limit: 2,
     address_limit: 1,
     language: locale,
-    municipality: citySettings && citySettings.length > 0 ? citySettings.join(',') : 'turku',
+    municipality: citySettings && citySettings.length > 0 ? citySettings.join(',') : config.cities,
   };
 
   const results = await smAPI.search(query, locale, citySettings, additionalOptions);

--- a/src/utils/newFetch/ServiceMapAPI.js
+++ b/src/utils/newFetch/ServiceMapAPI.js
@@ -24,7 +24,7 @@ export default class ServiceMapAPI extends HttpClient {
       service_limit: 500,
       address_limit: 500,
       language: locale,
-      municipality: citySettings && citySettings.length > 0 ? citySettings.join(',') : 'turku',
+      municipality: citySettings && citySettings.length > 0 ? citySettings.join(',') : config.cities,
       ...additionalOptions,
     };
 


### PR DESCRIPTION
# Update default value of the search query parameter

## Updates default value of municipality query parameter to be list of all cities if the user hasn't made any city selections. Previous default value narrowed results too much and it wasn't the expected functionality.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Change default value of one search query param
 1. src/components/SearchBar/createSuggestions.js
     * Import list of cities and add it into the municipality search parameter in case the user has not selected cities.
   
 2. src/utils/newFetch/ServiceMapAPI.js
     * Import list of cities and add it into the municipality search parameter in case the user has not selected cities.