### PR TITLE
Feature/shared-use-cars-content-update

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -53,7 +53,7 @@
 }
 
 .rental-cars-popup {
-  width: 470px;
+  width: 390px;
 }
 
 .ecocounter-popup > .leaflet-popup-content-wrapper {
@@ -67,7 +67,7 @@
 }
 
 .rental-cars-popup > .leaflet-popup-content-wrapper > .leaflet-popup-content {
-  width: 460px !important;
+  width: 380px !important;
 }
 
 @media (min-width: 750px) {
@@ -82,7 +82,7 @@
   }
 
   .rental-cars-popup > .leaflet-popup-content-wrapper > .leaflet-popup-content {
-    width: 370px !important;
+    width: 365px !important;
   }
 
   .ecocounter-popup {
@@ -100,7 +100,7 @@
   }
 
   .rental-cars-popup > .leaflet-popup-content-wrapper > .leaflet-popup-content {
-    width: 340px !important;
+    width: 335px !important;
   }
 
   .ecocounter-popup {

--- a/src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
+++ b/src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
@@ -7,16 +7,16 @@ import { ButtonBase, Typography } from '@material-ui/core';
 import { ReactSVG } from 'react-svg';
 import { DayPickerSingleDateController } from 'react-dates';
 import 'react-dates/initialize';
+import iconWalk from 'servicemap-ui-turku/assets/icons/icons-icon_walk.svg';
+import iconBicycle from 'servicemap-ui-turku/assets/icons/icons-icon_bicycle.svg';
+import iconCar from 'servicemap-ui-turku/assets/icons/icons-icon_car.svg';
+import LineChart from '../LineChart';
 import {
   fetchInitialHourData,
   fetchInitialDayDatas,
   fetchInitialWeekDatas,
   fetchInitialMonthDatas,
 } from '../EcoCounterRequests/ecoCounterRequests';
-import LineChart from '../LineChart';
-import iconWalk from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_walk.svg';
-import iconBicycle from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_bicycle.svg';
-import iconCar from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_car.svg';
 
 const EcoCounterContent = ({
   classes, intl, stationId, stationName,

--- a/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
+++ b/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
@@ -1,10 +1,10 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { PropTypes } from 'prop-types';
 import { useMap } from 'react-leaflet';
+import markerIcon from 'servicemap-ui-turku/assets/icons/icons-icon_ecocounter.svg';
 import MobilityPlatformContext from '../../../context/MobilityPlatformContext';
 import EcoCounterContent from '../EcoCounterContent';
 import { fetchEcoCounterStations } from '../EcoCounterRequests/ecoCounterRequests';
-import markerIcon from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_ecocounter.svg';
 
 const EcoCounterMarkers = ({ classes }) => {
   const [ecoCounterStations, setEcoCounterStations] = useState([]);

--- a/src/components/MobilityPlatform/BicycleStands/BicycleStands.js
+++ b/src/components/MobilityPlatform/BicycleStands/BicycleStands.js
@@ -1,11 +1,11 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { PropTypes } from 'prop-types';
 import { useMapEvents, useMap } from 'react-leaflet';
+import bicycleStandIcon from 'servicemap-ui-turku/assets/icons/icons-icon_bicycle-stand.svg';
+import circleIcon from 'servicemap-ui-turku/assets/icons/icons-icon-circle.svg';
 import MobilityPlatformContext from '../../../context/MobilityPlatformContext';
 import BicycleStandContent from '../BicycleStandContent';
 import { fetchMobilityMapData } from '../mobilityPlatformRequests/mobilityPlatformRequests';
-import bicycleStandIcon from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_bicycle-stand.svg';
-import circleIcon from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon-circle.svg';
 
 const BicycleStands = ({ classes }) => {
   const [bicycleStands, setBicycleStands] = useState([]);

--- a/src/components/MobilityPlatform/ChargerStationMarkers/ChargerStationMarkers.js
+++ b/src/components/MobilityPlatform/ChargerStationMarkers/ChargerStationMarkers.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { PropTypes } from 'prop-types';
+import chargerIcon from 'servicemap-ui-turku/assets/icons/icons-icon_charging_station.svg';
 import MobilityPlatformContext from '../../../context/MobilityPlatformContext';
 import ChargerStationContent from '../ChargerStationContent';
 import { fetchMobilityMapData } from '../mobilityPlatformRequests/mobilityPlatformRequests';
-import chargerIcon from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_charging_station.svg';
 
 const ChargerStationMarkers = ({ classes }) => {
   const [chargerStations, setChargerStations] = useState([]);

--- a/src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
+++ b/src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
@@ -2,10 +2,10 @@ import React, { useEffect, useState, useContext } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Typography } from '@material-ui/core';
+import routeUnitIcon from 'servicemap-ui-turku/assets/icons/icons-icon_culture_route.svg';
 import MobilityPlatformContext from '../../../context/MobilityPlatformContext';
 import { fetchCultureRoutesData } from '../mobilityPlatformRequests/mobilityPlatformRequests';
 import { selectRouteName } from '../utils/utils';
-import routeUnitIcon from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_culture_route.svg';
 
 const CultureRouteUnits = ({ classes }) => {
   const [cultureRouteUnits, setCultureRouteUnits] = useState([]);

--- a/src/components/MobilityPlatform/GasFillingStationMarkers/GasFillingStationMarkers.js
+++ b/src/components/MobilityPlatform/GasFillingStationMarkers/GasFillingStationMarkers.js
@@ -1,10 +1,10 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { PropTypes } from 'prop-types';
 import { useMap } from 'react-leaflet';
+import gasFillingIcon from 'servicemap-ui-turku/assets/icons/icons-icon_gas_station.svg';
 import MobilityPlatformContext from '../../../context/MobilityPlatformContext';
 import ChargerStationContent from '../ChargerStationContent';
 import { fetchMobilityMapData } from '../mobilityPlatformRequests/mobilityPlatformRequests';
-import gasFillingIcon from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_gas_station.svg';
 
 const GasFillingStationMarkers = ({ classes }) => {
   const [gasFillingStations, setGasFillingStations] = useState([]);

--- a/src/components/MobilityPlatform/RentalCars/RentalCars.js
+++ b/src/components/MobilityPlatform/RentalCars/RentalCars.js
@@ -1,11 +1,11 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { PropTypes } from 'prop-types';
 import { useMapEvents, useMap } from 'react-leaflet';
+import rentalCarIcon from 'servicemap-ui-turku/assets/icons/icons-icon_rental_car.svg';
+import providerIcon from 'servicemap-ui-turku/assets/icons/icons-icon_24rent.svg';
 import RentalCarsContent from './components/RentalCarsContent';
 import { fetchIotData } from '../mobilityPlatformRequests/mobilityPlatformRequests';
 import MobilityPlatformContext from '../../../context/MobilityPlatformContext';
-import rentalCarIcon from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_rental_car.svg';
-import providerIcon from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_24rent.svg';
 
 const RentalCars = ({ classes }) => {
   const [rentalCarsData, setRentalCarsData] = useState([]);

--- a/src/components/MobilityPlatform/RentalCars/components/RentalCarsContent/RentalCarsContent.js
+++ b/src/components/MobilityPlatform/RentalCars/components/RentalCarsContent/RentalCarsContent.js
@@ -1,11 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
 import { Link, Typography } from '@material-ui/core';
 
 const RentalCarsContent = ({ classes, intl, car }) => {
-  const locale = useSelector(state => state.user.locale);
-
   const titleText = (messageId, props = {}) => (
     <div className={classes.title}>
       <Typography variant="subtitle1" {...props}>
@@ -48,24 +45,14 @@ const RentalCarsContent = ({ classes, intl, car }) => {
     </div>
   );
 
-  const renderLocaleText = (textFi, textEn) => {
-    if (locale === 'fi') {
-      return textFi;
-    }
-    if (locale === 'en') {
-      return textEn;
-    }
-    return null;
-  };
-
-  const serviceProvider = '24Rent Oy';
+  const serviceProvider = '24Rent';
 
   return (
     <div className={classes.container}>
       {titleText('mobilityPlatform.content.rentalCars.title')}
       {contentText('mobilityPlatform.content.rentalCars.provider', serviceProvider)}
       <div className={classes.linkContainer}>
-        <Link target="_blank" href="https://www.24rent.fi">
+        <Link target="_blank" href={`https://www.24rent.fi/#/?city=${car.homeLocationData.fullAddress}`}>
           <Typography className={classes.link} variant="body2">
             {intl.formatMessage({
               id: 'mobilityPlatform.content.rentalCars.link',
@@ -87,20 +74,9 @@ const RentalCarsContent = ({ classes, intl, car }) => {
         </Typography>
       </div>
       {contentText('mobilityPlatform.content.rentalCars.address', car.homeLocationData.fullAddress)}
-      {locale !== 'sv' ? (
-        <>
-          <div className={classes.text}>
-            <Typography>
-              {renderLocaleText(car.homeLocationData.descriptions.fi, car.homeLocationData.descriptions.en)}
-            </Typography>
-          </div>
-        </>
-      ) : null}
-      {locale !== 'sv' ? (
-        <div className={classes.text}>
-          <Typography>{renderLocaleText(car.vehicleModelData.notes, car.vehicleModelData.notesen)}</Typography>
-        </div>
-      ) : null}
+      <div>
+        <img src={`https://vehicles-cdn.24rent.fi/${car.id}_medium.jpeg`} alt="shared use car" />
+      </div>
     </div>
   );
 };

--- a/src/components/MobilityPlatform/SnowPlows/SnowPlows.js
+++ b/src/components/MobilityPlatform/SnowPlows/SnowPlows.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { PropTypes } from 'prop-types';
+import snowPlowIcon from 'servicemap-ui-turku/assets/icons/icons-icon_snowplow.svg';
 import SnowPlowsContent from './components/SnowPlowsContent';
 import { fetchIotData } from '../mobilityPlatformRequests/mobilityPlatformRequests';
 import MobilityPlatformContext from '../../../context/MobilityPlatformContext';
-import snowPlowIcon from '../../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_snowplow.svg';
 
 const SnowPlows = ({ classes, intl }) => {
   const [iotData, setIotData] = useState(null);

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -633,14 +633,14 @@ const translations = {
   'mobilityPlatform.content.rentalCars.carInfo': 'Car information',
   'mobilityPlatform.content.rentalCars.available': 'Available',
   'mobilityPlatform.content.rentalCars.reserved': 'Reserved',
-  'mobilityPlatform.content.rentalCars.link': 'Webpage of the service provider',
+  'mobilityPlatform.content.rentalCars.link': 'https://www.24rent.fi',
 
   // Info text
   'mobilityPlatform.info.description.title': 'Route description',
   'mobilityPlatform.info.ecoCounter': 'Measurement points collect traffic information by measuring the number of users in different modes at selected destinations. The information has been provided by the City of Turku under the CC BY 4.0 license.',
   'mobilityPlatform.info.bicycleStands': 'The bicycle stands maintained by the City of Turku comprise three types of bicycle stands: covered and frame-locked bicycle stands, frame-lockable bicycle stands and tire racks, non-frame-lockable bicycle stands.',
   'mobilityPlatform.info.gasFillingStations': 'Public gas filling stations in the Turku area. The information on the gas stations is based on information from the traffic situation website maintained by Fintraffic, https://liikennetilanne.fintraffic.fi',
-  'mobilityPlatform.info.rentalCars': 'The car share vehicles are rental cars. The available cars are visible on the map. Information about the cars is provided by 24Rent Oy.',
+  'mobilityPlatform.info.rentalCars': 'The car share vehicles are rental cars. The available cars are visible on the map. Information about the cars is provided by 24Rent.',
 
   // Bicycle routes
   'mobilityPlatform.menu.bicycleRoutes.euroVelo': 'The EuroVelo 10, is the European cycle route that stretches along the Finnish costal line. The distance between Helsinki and Turku has roadside directions for the route.',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -637,14 +637,14 @@ const translations = {
   'mobilityPlatform.content.rentalCars.carInfo': 'Auton tiedot',
   'mobilityPlatform.content.rentalCars.available': 'Vapaa auto',
   'mobilityPlatform.content.rentalCars.reserved': 'Käytössä',
-  'mobilityPlatform.content.rentalCars.link': 'Palveluntarjoajan sivut',
+  'mobilityPlatform.content.rentalCars.link': 'https://www.24rent.fi',
 
   // Info text
   'mobilityPlatform.info.description.title': 'Tietoja reitistä',
   'mobilityPlatform.info.ecoCounter': 'Laskentapisteet keräävät tietoa liikenteestä mittaamalla eri liikennemuotojen käyttäjien määriä valituissa kohteissa. Tiedot on toimittanut Turun kaupunki käyttöluvan CC BY 4.0 nojalla.',
   'mobilityPlatform.info.bicycleStands': 'Turun kaupungin ylläpitämät polkupyöräpysäköintipaikat käsittävät kolmentyyppisiä pyörätelineitä: katetut ja runkolukittavat pyörätelineet, runkolukittavat pyörätelineet ja rengastelineelliset, ei runkolukittavat pyörätelineet.',
   'mobilityPlatform.info.gasFillingStations': 'Turun alueen julkiset kaasutankkausasemat. Tankkausasemien tiedot perustuvat Fintrafficin ylläpitämän liikennetilanne (https://liikennetilanne.fintraffic.fi) -sivuston tietoihin.',
-  'mobilityPlatform.info.rentalCars': 'Yhteiskäyttöautot ovat vapaasti vuokrattavia autoja. Kartalla näytetään tällä hetkellä vapaana olevat autot. Tiedot niistä tulevat 24Rent Oy:lta.',
+  'mobilityPlatform.info.rentalCars': 'Yhteiskäyttöautot ovat vapaasti vuokrattavia autoja. Kartalla näytetään tällä hetkellä vapaana olevat autot. Tiedot niistä tulevat 24Rent:ltä.',
 
   // Bicycle routes
   'mobilityPlatform.menu.bicycleRoutes.euroVelo': 'EuroVelo 10 on eurooppalainen Suomen rannikkoa seuraava polkupyöräreitti. Helsingin ja Turun välisellä matkalla reitti on merkitty opastein.',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -635,14 +635,14 @@ const translations = {
   'mobilityPlatform.content.rentalCars.carInfo': 'Bilens uppgiter',
   'mobilityPlatform.content.rentalCars.available': 'Ledig bil',
   'mobilityPlatform.content.rentalCars.reserved': 'Reseverad',
-  'mobilityPlatform.content.rentalCars.link': 'Websida av tjänsteleverantör',
+  'mobilityPlatform.content.rentalCars.link': 'https://www.24rent.fi',
 
   // Info text
   'mobilityPlatform.info.description.title': 'Beskrivning av rutten',
   'mobilityPlatform.info.ecoCounter': 'Beräkningspunkter samlar in trafikdata genom att mäta antalet användare i olika lägen på utvalda destinationer. Informationen har tillhandahållits av Åbo stad under licensen CC BY 4.0.',
   'mobilityPlatform.info.bicycleStands': 'De cykelparkeringar som Åbo stad underhåller består av tre typer av cykelställ: täckta och ramlåsbara cykelställ, ramlåsbara cykelställ och däckställ, icke-ramlåsbara cykelställ.',
   'mobilityPlatform.info.gasFillingStations': 'Offentliga gastankstationer i Åboområdet. Informationen om gastankstationerna baseras på information som hämtas från webbplatsen om trafikläget https://liikennetilanne.fintraffic.fi,  som underhålls av Fintraffic.',
-  'mobilityPlatform.info.rentalCars': 'Bilpool bilarna är hyrbilar. Kartan visar lediga bilar. Informationen om bilarna kommer från 24Rent Ab.',
+  'mobilityPlatform.info.rentalCars': 'Bilpool bilarna är hyrbilar. Kartan visar lediga bilar. Informationen om bilarna kommer från 24Rent.',
 
   // Bicycle routes
   'mobilityPlatform.menu.bicycleRoutes.euroVelo': 'EuroVelo 10 är en europeisk cykelrutt som följer den finländska kusten. Sträckan mellan Helsingfors och Åbo är skyltad.',

--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -5,6 +5,9 @@ import {
   Typography, FormGroup, FormControl, FormControlLabel, Switch, Button,
 } from '@material-ui/core';
 import { ReactSVG } from 'react-svg';
+import iconWalk from 'servicemap-ui-turku/assets/icons/icons-icon_walk.svg';
+import iconBicycle from 'servicemap-ui-turku/assets/icons/icons-icon_bicycle.svg';
+import iconCar from 'servicemap-ui-turku/assets/icons/icons-icon_car.svg';
 import MobilityPlatformContext from '../../context/MobilityPlatformContext';
 import {
   fetchCultureRouteNames,
@@ -15,9 +18,6 @@ import TitleBar from '../../components/TitleBar';
 import InfoTextBox from '../../components/MobilityPlatform/InfoTextBox';
 import Description from './components/Description';
 import RouteLength from './components/RouteLength';
-import iconWalk from '../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_walk.svg';
-import iconBicycle from '../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_bicycle.svg';
-import iconCar from '../../../node_modules/servicemap-ui-turku/assets/icons/icons-icon_car.svg';
 
 const MobilitySettingsView = ({ classes, intl }) => {
   const [openWalkSettings, setOpenWalkSettings] = useState(false);


### PR DESCRIPTION
# Update content view of shared use cars

## Add link to image of the car, remove description and update link. Also shorten image imports from the theme package.

### Card 136

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Update modal content
 1. src/components/MobilityPlatform/RentalCars/components/RentalCarsContent/RentalCarsContent.js
     * Add image, remove description and update link of the service provider.
   
 2. src/App.css
     * Adjust modal width values.
    
 3. src/i18n/en.js, src/i18n/fi.js, src/i18n/sv.js
     * Update texts.
     
#### Shorten icon imports
 1. src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
     * Shorten url of icon imports since specifying full location ('../../node_modules' etc) is not necessary.
   
 2. src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
     * Same as above
    
 3. src/components/MobilityPlatform/BicycleStands/BicycleStands.js
      * Same as above

 4. src/components/MobilityPlatform/ChargerStationMarkers/ChargerStationMarkers.js
     * Same as above
    
 5. src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
      * Same as above

 6. src/components/MobilityPlatform/GasFillingStationMarkers/GasFillingStationMarkers.js
     * Same as above
    
 7. src/components/MobilityPlatform/RentalCars/RentalCars.js
      * Same as above

 8. src/components/MobilityPlatform/SnowPlows/SnowPlows.js
     * Same as above
    
 9. src/views/MobilitySettingsView/MobilitySettingsView.js
      * Same as above