### PR TITLE
Cookie script conditional import from theme

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,10 @@ REITTIOPAS_URL="https://reittiopas.foli.fi/reitti/"
 THEME_PKG=1
 MOBILITY_PLATFORM_API="https://palvelukartta.turku.fi"
 
+# COOKIEBOT_DATA_CBID is used as the data-cbid value of the Cookiebot script.
+# THEME_PKG must also be set to "1" or "true", ie. THEME_PKG=1.
+# COOKIEBOT_DATA_CBID='string containing the data_cbid value'
+
 # DOMAIN_MAP_POSITIONS is array of arrays in string format. Using format "domain1,lat1,lon1;domain2,lat2,lon2"
 # For example:
 # DOMAIN_MAP_POSITIONS="palvelukartta.espoo.fi,60.205176,24.656995;palvelukartta.hel.fi,60.170377597530016,24.941309323934886"

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@
 
 .prettierrc
 /dist
-
+/.idea
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/browserTests/accessibilityTest.js
+++ b/browserTests/accessibilityTest.js
@@ -3,6 +3,7 @@ import axeCheck from 'axe-testcafe';
 import config from './config';
 import focusIndicatorTest from './focusIndicatorTest';
 import componentContrastTest from './componentContrastTest';
+import {waitForReact} from 'testcafe-react-selectors';
 
 const { server } = config;
 
@@ -12,7 +13,11 @@ const axeCheckHandler = t => {
   return axeCheck(t, null, axeOptions);
 };
 
-fixture`TestCafe Axe test: frontpage`.page`http://${server.address}:${server.port}/fi/`;
+fixture`TestCafe Axe test: frontpage`
+    .page`http://${server.address}:${server.port}/fi/`
+    .beforeEach(async () => {
+      await waitForReact();
+    });
 
 test('Automated accessibility testing', async t => {
   await axeCheckHandler(t);
@@ -22,7 +27,11 @@ focusIndicatorTest();
 componentContrastTest('SMButton');
 componentContrastTest('BackButton');
 
-fixture`TestCafe Axe test: search page`.page`http://${server.address}:${server.port}/fi/search?q=kirjasto`;
+fixture`TestCafe Axe test: search page`
+    .page`http://${server.address}:${server.port}/fi/search?q=kirjasto`
+    .beforeEach(async () => {
+        await waitForReact();
+    });
 
 test('Automated accessibility testing', async t => {
   await axeCheckHandler(t);
@@ -32,7 +41,11 @@ focusIndicatorTest();
 componentContrastTest('SMButton');
 componentContrastTest('BackButton');
 
-fixture`TestCafe Axe test: unit page`.page`http://${server.address}:${server.port}/fi/unit/148`;
+fixture`TestCafe Axe test: unit page`
+    .page`http://${server.address}:${server.port}/fi/unit/148`
+    .beforeEach(async() => {
+      await waitForReact();
+    });
 
 test('Automated accessibility testing', async t => {
   await axeCheckHandler(t);
@@ -42,7 +55,11 @@ focusIndicatorTest();
 componentContrastTest('SMButton');
 componentContrastTest('BackButton');
 
-fixture`TestCafe Axe test: service page`.page`http://${server.address}:${server.port}/fi/service/279`;
+fixture`TestCafe Axe test: service page`
+    .page`http://${server.address}:${server.port}/fi/service/279`
+    .beforeEach(async() => {
+        await waitForReact();
+    });
 
 test('Automated accessibility testing', async t => {
   await axeCheckHandler(t);
@@ -53,7 +70,10 @@ componentContrastTest('SMButton');
 componentContrastTest('BackButton');
 
 fixture`TestCafe Axe test: address page`
-  .page`http://${server.address}:${config.server.port}/fi/address/turku/Aurakatu/1`;
+    .page`http://${server.address}:${config.server.port}/fi/address/turku/Aurakatu/1`
+    .beforeEach(async() => {
+        await waitForReact();
+    });
 
 test('Automated accessibility testing', async t => {
   await axeCheckHandler(t);
@@ -63,8 +83,11 @@ focusIndicatorTest();
 componentContrastTest('SMButton');
 componentContrastTest('BackButton');
 
-fixture`TestCafe Axe test: area page`.page`http://${server.address}:${config.server.port}/fi/area`;
-
+fixture`TestCafe Axe test: area page`
+    .page`http://${server.address}:${config.server.port}/fi/area`
+    .beforeEach(async() => {
+        await waitForReact();
+    });
 test('Automated accessibility testing', async t => {
   await axeCheckHandler(t);
 });
@@ -73,7 +96,11 @@ focusIndicatorTest();
 componentContrastTest('SMButton');
 componentContrastTest('BackButton');
 
-fixture`TestCafe Axe test: service tree page`.page`http://${server.address}:${server.port}/fi/services`;
+fixture`TestCafe Axe test: service tree page`
+    .page`http://${server.address}:${server.port}/fi/services`
+    .beforeEach(async() => {
+      await waitForReact();
+    });
 
 test('Automated accessibility testing', async t => {
   await axeCheckHandler(t);
@@ -96,7 +123,11 @@ componentContrastTest('SMButton');
 componentContrastTest('BackButton'); */
 
 // Mobility platform page
-fixture`TestCafe Axe test: mobility platform page`.page`http://${server.address}:${server.port}/fi/mobility`;
+fixture`TestCafe Axe test: mobility platform page`
+    .page`http://${server.address}:${server.port}/fi/mobility`
+    .beforeEach(async() => {
+      await waitForReact();
+    });
 
 test('Automated accessibility testing', async t => {
   await axeCheckHandler(t);

--- a/browserTests/componentContrastTest.js
+++ b/browserTests/componentContrastTest.js
@@ -6,6 +6,7 @@ export default (component) => {
     return component;
   }
 
+
   test('Component has good contrast ratio with background', async (t) => {
     const componentName = getComponentName();
     const elements = ReactSelector(`main ${componentName}`);
@@ -20,7 +21,7 @@ export default (component) => {
       ) {
         elementBorder = await element.getStyleProperty('border-top-color');
       }
-      
+
       const parentBackground = await getParentElementBG(element, element.parent())
       const elementColor = await getElementBG(await element)
 

--- a/browserTests/config.js
+++ b/browserTests/config.js
@@ -2,5 +2,8 @@ export default {
   server: {
     address: 'localhost',
     port: 2048
+  },
+  clientScripts: {
+    content: 'const element = document.getElementById("CybotCookiebotDialog");if(element){element.parentNode.removeChild(element);}'
   }
 }

--- a/browserTests/searchTest.js
+++ b/browserTests/searchTest.js
@@ -158,7 +158,7 @@ test('ServiceItem click event takes to service page', async(t) => {
 //   const button = await Selector('#ExpandSuggestions');
 //   await t
 //     .click(button);
-  
+
 //   const backButton = await ReactSelector('BackButton');
 //   await t
 //     .expect(backButton.focused).ok('Titlebar\'s back button should have focus')
@@ -252,7 +252,7 @@ test('ResultList accessibility attributes are OK', async(t) => {
 //     const expandedSuggestionsButton = await Selector('#ExpandSuggestions');
 //     const esbRole = await expandedSuggestionsButton.getAttribute('role')
 //     await t
-//       // We expect ExpandedSearchButton to have role link since it takes to another view 
+//       // We expect ExpandedSearchButton to have role link since it takes to another view
 //       .expect(esbRole).eql('link', 'ExpandedSearchButton should be considered a link');
 // });
 
@@ -356,7 +356,7 @@ test('SettingsInfo works correctly', async(t) => {
 //   await t
 //     .click(clickedItem)
 //     .expect(getLocation()).contains(`http://${server.address}:${server.port}/fi/search?q=${text}`)
-    
+
 // });
 
 fixture`Pagination tests`

--- a/browserTests/settingsTest.js
+++ b/browserTests/settingsTest.js
@@ -7,13 +7,13 @@ const { server } = config;
 
 
 fixture`Settings view tests`
-  .page`http://${server.address}:${server.port}/fi/`
+  .page(`http://${server.address}:${server.port}/fi/`)
   .beforeEach(async () => {
     await waitForReact();
   });
 
 const openSettings = async t => {
-  const openButton = Selector('#SettingsButtonaccessibilitySettings');
+  const openButton = await Selector('#SettingsButtonaccessibilitySettings');
   await t
     .click(openButton)
   ;
@@ -44,7 +44,7 @@ test('Settings does work like dialog', async (t) => {
     .expect(settingsContainer.getAttribute('role')).eql('dialog', "Expected container to have role dialog")
     .click(ReactSelector('Settings').find('span').nth(0))
     .pressKey('tab') // Tab to close button
-    .pressKey('shift+tab') // Shift tab back to 
+    .pressKey('shift+tab') // Shift tab back to
     .expect(buttons.nth(buttonCount - 1).focused).ok('Expected dialog to loop backwards to last element of dialog')
     .pressKey('tab')
     .expect(closeButton.focused).ok('Expected close button to be focused after looping back to start')
@@ -52,7 +52,7 @@ test('Settings does work like dialog', async (t) => {
 });
 
 test('Settings radio and checkbox buttons are grouped', async (t) => {
-  openSettings(t);
+  await openSettings(t);
 
   const settings = ReactSelector('Settings');
   const checkboxGroup = settings.find('[aria-labelledby=SenseSettings]');
@@ -75,7 +75,7 @@ test('Settings radio and checkbox buttons are grouped', async (t) => {
 });
 
 test('Settings saves correctly', async (t) => {
-  openSettings(t);
+  await openSettings(t);
 
   const settings = ReactSelector('Settings');
   const checkboxGroup = settings.find('[aria-labelledby=SenseSettings]');
@@ -116,4 +116,4 @@ test('Settings saves correctly', async (t) => {
     )
     .expect(title.focused).ok('Expect focus to move to title on confirmation box save')
   ;
-})
+});

--- a/server/externalScripts.js
+++ b/server/externalScripts.js
@@ -3,6 +3,17 @@ export function cookieHubCode (req) {
     return '';
   }
 
+  if ((process.env.THEME_PKG === '1' || process.env.THEME_PKG === 'true') && process.env.COOKIEBOT_DATA_CBID) {
+    // Get CookieBot script if THEME_PKG is active and COOKIEBOT_DATA_CBID is defined.
+    try {
+      const {getCookieScript} = require('servicemap-ui-turku/assets/js');
+      return getCookieScript(process.env.COOKIEBOT_DATA_CBID);
+    } catch (e) {
+        console.error(e);
+        return '';
+    }
+  }
+
   let cookiehubURL;
   // Attempt to parse COOKIEHUB_DOMAINS object
   try {
@@ -29,7 +40,7 @@ export function cookieHubCode (req) {
     console.error(`Error while parsing COOKIEHUB_DOMAINS variable: ${e.message}`);
     return '';
   }
-  
+
   return `
     <script type="text/javascript">
       var cpm = {


### PR DESCRIPTION

## Cookiebot script is now imported from the theme package with data-cbid value based on new env variable COOKIEBOT_DATA_CBID

#### Cookie script is now imported from the theme package if the theme package is active and the new COOKIEBOT_DATA_CBID env variable is set. COOKIEBOT_DATA_CBID is the data-cbid value of the cookiebot script so it must be set correctly in order for the cookiebot banner/script to work.

-----------------------------------------------------------------------------------------------
Changes:
- **server/externalScripts.js**
Added new condition inside the `cookieHubCode` function that imports the cookie script from the theme package if the correct env variables are set. If for some reason the path to the theme package doesn't exist -> error is thrown and displayed in the console.

- **.gitignore**
Added `.idea` folder to be ignored, folder contains webstorm/jetbrains IDE specific settings that shouldn't be tracked.

- **.env.example**
Added information regarding the new `COOKIEBOT_DATA_CBID` env variable.