### PR TITLE
Add better label for result order select element

### DIFF
--- a/src/components/ResultOrderer/ResultOrderer.js
+++ b/src/components/ResultOrderer/ResultOrderer.js
@@ -77,7 +77,7 @@ const ResultOrderer = ({
   return (
     <form className={classes.root} autoComplete="off">
       <FormControl className={classes.formControl}>
-        <Typography color="inherit" variant="caption" className={classes.inputLabel}>
+        <Typography color="inherit" variant="caption" component="label" for="result-sorter" className={classes.inputLabel}>
           <FormattedMessage id="sorting.label" />
         </Typography>
         <Select


### PR DESCRIPTION
# Add better label for result order select element

## Result orderer select element was missing linked label. Now it should read the label when navigating to the element.

### Card 145

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Add better label for result order select element
 1. src/components/ResultOrderer/ResultOrderer.js
     * Add linked label for result orderer.
