### PR TITLE
Display culture route unit descriptions

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -70,6 +70,14 @@
   width: 380px !important;
 }
 
+.culture-route-unit-popup {
+  width: 400px;
+}
+
+.culture-route-unit-popup > .leaflet-popup-content-wrapper > .leaflet-popup-content {
+  width: 400px !important;
+}
+
 @media (min-width: 750px) {
   .charger-stations-popup > .leaflet-popup-content-wrapper > .leaflet-popup-content {
     width: 350px !important;
@@ -92,6 +100,14 @@
   .ecocounter-popup > .leaflet-popup-content-wrapper > .leaflet-popup-content {
     width: 370px !important;
   }
+
+  .culture-route-unit-popup {
+    width: 380px;
+  }
+  
+  .culture-route-unit-popup > .leaflet-popup-content-wrapper > .leaflet-popup-content {
+    width: 380px !important;
+  }
 }
 
 @media (max-width: 380px) {
@@ -108,6 +124,14 @@
   }
 
   .ecocounter-popup > .leaflet-popup-content-wrapper > .leaflet-popup-content {
+    width: 350px !important;
+  }
+
+  .culture-route-unit-popup {
+    width: 350px;
+  }
+  
+  .culture-route-unit-popup > .leaflet-popup-content-wrapper > .leaflet-popup-content {
     width: 350px !important;
   }
 }

--- a/src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
+++ b/src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
@@ -1,7 +1,10 @@
 import React, { useContext } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Typography } from '@material-ui/core';
+import { useIntl } from 'react-intl';
+import { useMap } from 'react-leaflet';
+import { Typography, ButtonBase } from '@material-ui/core';
+import { Close } from '@material-ui/icons';
 import routeUnitIcon from 'servicemap-ui-turku/assets/icons/icons-icon_culture_route.svg';
 import MobilityPlatformContext from '../../../context/MobilityPlatformContext';
 import { selectRouteName } from '../utils/utils';
@@ -9,7 +12,10 @@ import { selectRouteName } from '../utils/utils';
 const CultureRouteUnits = ({ classes, cultureRouteUnits }) => {
   const { cultureRouteId } = useContext(MobilityPlatformContext);
 
+  const intl = useIntl();
+
   const locale = useSelector(state => state.user.locale);
+  const map = useMap();
 
   const { Marker, Popup } = global.rL;
   const { icon } = global.L;
@@ -19,19 +25,57 @@ const CultureRouteUnits = ({ classes, cultureRouteUnits }) => {
     iconSize: [45, 45],
   });
 
+  const closePopup = () => {
+    if (map) {
+      map.closePopup();
+    }
+  };
+
   const activeCultureRouteUnits = cultureRouteUnits.filter(item => item.mobile_unit_group.id === cultureRouteId);
+
+  const renderDescription = (descriptionFi, descriptionEn, descriptionSv, nameFi, nameEn, nameSv) => {
+    let desc = descriptionFi;
+    let name = nameFi;
+    if (locale === 'sv') {
+      desc = descriptionSv;
+      name = nameSv;
+    } else if (locale === 'en') {
+      desc = descriptionEn;
+      name = nameEn;
+    }
+    if (!desc) {
+      return intl.formatMessage({ id: 'mobilityPlatform.content.description.notAvailable' });
+    }
+    return desc.replace(name, '');
+  };
 
   return (
     <>
       <div>
-        {activeCultureRouteUnits && activeCultureRouteUnits.length > 0
+        {activeCultureRouteUnits
+          && activeCultureRouteUnits.length > 0
           && activeCultureRouteUnits.map(item => (
             <Marker key={item.id} icon={customIcon} position={[item.geometry_coords.lat, item.geometry_coords.lon]}>
-              <Popup>
+              <Popup closeButton={false} maxHeight={400} className="culture-route-unit-popup">
                 <div className={classes.popupInner}>
-                  <div className={classes.subtitle}>
-                    <Typography variant="body2">
+                  <div className={classes.header}>
+                    <Typography variant="subtitle1">
                       {selectRouteName(locale, item.name, item.name_en, item.name_sv)}
+                    </Typography>
+                    <ButtonBase onClick={() => closePopup()} className={classes.popupCloseButton}>
+                      <Close className={classes.infoIcon} />
+                    </ButtonBase>
+                  </div>
+                  <div className={classes.content}>
+                    <Typography variant="body2">
+                      {renderDescription(
+                        item.description,
+                        item.description_en,
+                        item.description_sv,
+                        item.name,
+                        item.name_en,
+                        item.name_sv,
+                      )}
                     </Typography>
                   </div>
                 </div>

--- a/src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
+++ b/src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
@@ -37,6 +37,9 @@ const CultureRouteUnits = ({ classes, cultureRouteUnits }) => {
    * Returns description based on locale
    * Renders linebreaks as well
    * If description does not exists, return message
+   * @param {string} descriptionFi
+   * @param {string} descriptionEn
+   * @param {string} descriptionSv
    */
   const renderDescription = (descriptionFi, descriptionEn, descriptionSv) => {
     const obj = { key: undefined, text: '' };

--- a/src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
+++ b/src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
@@ -35,24 +35,33 @@ const CultureRouteUnits = ({ classes, cultureRouteUnits }) => {
 
   /**
    * Returns description based on locale
+   * Renders linebreaks as well
    * If description does not exists, return message
-   * First line of description is route name
-   * To avoid repetition route name will be hidden inside description
    */
-  const renderDescription = (descriptionFi, descriptionEn, descriptionSv, nameFi, nameEn, nameSv) => {
-    let desc = descriptionFi;
-    let name = nameFi;
-    if (locale === 'sv') {
-      desc = descriptionSv;
-      name = nameSv;
-    } else if (locale === 'en') {
-      desc = descriptionEn;
-      name = nameEn;
+  const renderDescription = (descriptionFi, descriptionEn, descriptionSv) => {
+    const obj = { key: undefined, text: '' };
+    if (descriptionFi && locale === 'fi') {
+      obj.key = 'fi';
+      obj.text = descriptionFi;
+    } else if (descriptionEn && locale === 'en') {
+      obj.key = 'en';
+      obj.text = descriptionEn;
+    } else if (descriptionSv && locale === 'sv') {
+      obj.key = 'sv';
+      obj.text = descriptionSv;
     }
-    if (!desc) {
-      return intl.formatMessage({ id: 'mobilityPlatform.content.description.notAvailable' });
+    if (obj.key) {
+      return obj.text.split('\n\n\n').map(paragraph => (
+        <Typography key={Math.random()} variant="body2">
+          {paragraph.split('\n').reduce((total, line) => [total, <br key={Math.random()} />, line])}
+        </Typography>
+      ));
     }
-    return desc.replace(name, '');
+    return (
+      <Typography variant="body2">
+        {intl.formatMessage({ id: 'mobilityPlatform.content.description.notAvailable' })}
+      </Typography>
+    );
   };
 
   /**
@@ -78,16 +87,11 @@ const CultureRouteUnits = ({ classes, cultureRouteUnits }) => {
                     </ButtonBase>
                   </div>
                   <div className={classes.content}>
-                    <Typography variant="body2">
-                      {renderDescription(
-                        item.description,
-                        item.description_en,
-                        item.description_sv,
-                        item.name,
-                        item.name_en,
-                        item.name_sv,
-                      )}
-                    </Typography>
+                    {renderDescription(
+                      item.description,
+                      item.description_en,
+                      item.description_sv,
+                    )}
                   </div>
                 </div>
               </Popup>

--- a/src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
+++ b/src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
@@ -33,6 +33,12 @@ const CultureRouteUnits = ({ classes, cultureRouteUnits }) => {
 
   const activeCultureRouteUnits = cultureRouteUnits.filter(item => item.mobile_unit_group.id === cultureRouteId);
 
+  /**
+   * Returns description based on locale
+   * If description does not exists, return message
+   * First line of description is route name
+   * To avoid repetition route name will be hidden inside description
+   */
   const renderDescription = (descriptionFi, descriptionEn, descriptionSv, nameFi, nameEn, nameSv) => {
     let desc = descriptionFi;
     let name = nameFi;
@@ -49,6 +55,11 @@ const CultureRouteUnits = ({ classes, cultureRouteUnits }) => {
     return desc.replace(name, '');
   };
 
+  /**
+   * Default close button is set to false, because it would overlap with the scrollbar
+   * It is easier to make a custom close button than to edit the default close button
+   */
+
   return (
     <>
       <div>
@@ -63,7 +74,7 @@ const CultureRouteUnits = ({ classes, cultureRouteUnits }) => {
                       {selectRouteName(locale, item.name, item.name_en, item.name_sv)}
                     </Typography>
                     <ButtonBase onClick={() => closePopup()} className={classes.popupCloseButton}>
-                      <Close className={classes.infoIcon} />
+                      <Close className={classes.closeIcon} />
                     </ButtonBase>
                   </div>
                   <div className={classes.content}>

--- a/src/components/MobilityPlatform/CultureRouteUnits/styles.js
+++ b/src/components/MobilityPlatform/CultureRouteUnits/styles.js
@@ -1,9 +1,22 @@
 export default theme => ({
   popupInner: {
-    margin: theme.spacing(1.5),
+    padding: theme.spacing(1.5),
   },
-  subtitle: {
-    width: '88%',
+  header: {
+    width: '98%',
     marginBottom: theme.spacing(1),
+    borderBottom: '1px solid rgba(0, 0, 0, 255)',
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  popupCloseButton: {
+    padding: theme.spacing(0.8),
+    '&:hover': {
+      cursor: 'pointer',
+      borderRadius: '5px',
+      border: '1px solid rgba(0, 0, 0, 255)',
+    },
   },
 });

--- a/src/components/MobilityPlatform/CultureRouteUnits/styles.js
+++ b/src/components/MobilityPlatform/CultureRouteUnits/styles.js
@@ -12,11 +12,17 @@ export default theme => ({
     alignItems: 'center',
   },
   popupCloseButton: {
-    padding: theme.spacing(0.8),
+    padding: theme.spacing(1),
     '&:hover': {
       cursor: 'pointer',
       borderRadius: '5px',
       border: '1px solid rgba(0, 0, 0, 255)',
     },
+  },
+  closeIcon: {
+    fontSize: '1.25rem',
+    width: '1.25rem',
+    height: '1.25rem',
+    lineHeight: '1.4rem',
   },
 });

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -651,6 +651,7 @@ const translations = {
   'mobilityPlatform.content.parkingChargeZones.price.weekDays': 'Toll charge on workdays',
   'mobilityPlatform.content.parkingChargeZones.price.saturday': 'Toll charge on saturdays',
   'mobilityPlatform.content.parkingChargeZones.price.sunday': 'Toll charge on sundays',
+  'mobilityPlatform.content.description.notAvailable': 'Description text is not available.',
 
   // Info text
   'mobilityPlatform.info.description.title': 'Route description',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -655,6 +655,7 @@ const translations = {
   'mobilityPlatform.content.parkingChargeZones.price.weekDays': 'Maksullisuus arkisin',
   'mobilityPlatform.content.parkingChargeZones.price.saturday': 'Maksullisuus lauantaisin',
   'mobilityPlatform.content.parkingChargeZones.price.sunday': 'Maksullisuus sunnuntaisin',
+  'mobilityPlatform.content.description.notAvailable': 'Kuvaustekstiä ei ole saatavilla.',
 
   // Info text
   'mobilityPlatform.info.description.title': 'Tietoja reitistä',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -653,6 +653,7 @@ const translations = {
   'mobilityPlatform.content.parkingChargeZones.price.weekDays': 'Avgiftsbelagd vardagar',
   'mobilityPlatform.content.parkingChargeZones.price.saturday': 'Avgiftsbelagd lördagar',
   'mobilityPlatform.content.parkingChargeZones.price.sunday': 'Avgiftsbelagd söndagar',
+  'mobilityPlatform.content.description.notAvailable': 'Beskrivningstext är inte tillgänglig.',
 
   // Info text
   'mobilityPlatform.info.description.title': 'Beskrivning av rutten',


### PR DESCRIPTION
# Display culture route unit descriptions

## Display culture route unit descriptions inside Leaflet modal.

### Card 135

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Display descriptions of route units
 1. src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
     * Add function that displays description text based on locale. Add max height value to make the modal scrollable if the text is long. Add custom close button for the modal, because it is easier to customize than the default close button. It will also prevent scrollbar overlapping with the close button.
   
 2. src/App.css
     * Add width values for the modal.
    
 3. src/components/MobilityPlatform/CultureRouteUnits/styles.js
     * Update styles.
     
4. src/i18n/en.js & src/i18n/fi.js & src/i18n/sv.js
     * Update texts.

#### Icon style update & add comment
 1. src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
     * Add comments and rename icon class.
   
 2. src/components/MobilityPlatform/CultureRouteUnits/styles.js
     * Add styles for the close icon. Adjust padding.

#### Display description text with line breaks
 1. src/components/MobilityPlatform/CultureRouteUnits/CultureRouteUnits.js
     * Render text with line breaks based on data content (data includes \n\n characters).