### PR TITLE
Display extended info about parking charge zones

### DIFF
--- a/browserTests/browserTest.js
+++ b/browserTests/browserTest.js
@@ -61,13 +61,13 @@ test('Contrast does change', async (t) => {
   ;
 });
 
-fixture`Map tests`
+/* fixture`Map tests`
   .page`http://${server.address}:${server.port}/fi`
   .beforeEach(async () => {
     await waitForReact();
-  });
+  }); */
 
-test('Transit marker visible after zoom', async (t) => {
+/* test('Transit marker visible after zoom', async (t) => {
   const zoomIn  = Selector('.zoomIn');
   const markers = Selector('.leaflet-marker-icon');
   
@@ -85,4 +85,4 @@ test('Transit marker visible after zoom', async (t) => {
 
   await t
     .expect(markerCount).gt(0, 'no transit markers found on high zoom')
-});
+}); */

--- a/browserTests/unitPageTest.js
+++ b/browserTests/unitPageTest.js
@@ -7,7 +7,7 @@ const { server } = config;
 /* eslint-disable */
 
 fixture`Unit page tests`
-  .page`http://${server.address}:${server.port}/fi/unit/8215`
+  .page`http://${server.address}:${server.port}/fi/unit/148`
   .beforeEach(async () => {
     await waitForReact();
   });

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -658,10 +658,15 @@ const translations = {
   'mobilityPlatform.info.ecoCounter': 'Measurement points collect traffic information by measuring the number of users in different modes at selected destinations. The information has been provided by the City of Turku under the CC BY 4.0 license.',
   'mobilityPlatform.info.bicycleStands': 'The bicycle stands maintained by the City of Turku comprise three types of bicycle stands: covered and frame-locked bicycle stands, frame-lockable bicycle stands and tire racks, non-frame-lockable bicycle stands.',
   'mobilityPlatform.info.gasFillingStations': 'Public gas filling stations in the Turku area. The information on the gas stations is based on information from the traffic situation website maintained by Fintraffic, https://liikennetilanne.fintraffic.fi',
-  'mobilityPlatform.info.rentalCars': 'The car share vehicles are rental cars. The available cars are visible on the map. Information about the cars is provided by 24Rent Oy.',
+  'mobilityPlatform.info.rentalCars': 'The car share vehicles are rental cars. The available cars are visible on the map. Information about the cars is provided by 24Rent.',
   'mobilityPlatform.info.parkingSpaces': 'The map shows public parking areas of Turku. The red colour next to a parking area indicates that it is almost full. To see the exact number of available spaces, click on the parking area on the map. The information on parking areas comes from parking hub of Turku.',
   'mobilityPlatform.info.chargingStations': 'Turku area public car e-charging points. The charging point information is based on a mappig carried out 05/2022.',
-  'mobilityPlatform.info.parkingChargeZones': 'Parking charge zones of Turku.',
+  'mobilityPlatform.info.parkingChargeZones.paragraph.1': 'There are three different zones with different hourly rates in the City of Turku.',
+  'mobilityPlatform.info.parkingChargeZones.paragraph.2': 'Zone 3 applies to the area between the boundaries of Zone 2 and the city limits.',
+  'mobilityPlatform.info.parkingChargeZones.paragraph.3': 'However, the charge is always determined by the traffic signs in force and applies to the streets of Turku and the city’s own areas, such as the market hall and the City Hall.',
+  'mobilityPlatform.info.parkingChargeZones.zone.1': 'Zone I (downtown): 3,00 €/hour',
+  'mobilityPlatform.info.parkingChargeZones.zone.2': 'Zone II : 1,50 €/hour',
+  'mobilityPlatform.info.parkingChargeZones.zone.3': 'Zone III: 0,60€/hour',
 
   // Bicycle routes
   'mobilityPlatform.menu.bicycleRoutes.euroVelo': 'The EuroVelo 10, is the European cycle route that stretches along the Finnish costal line. The distance between Helsinki and Turku has roadside directions for the route.',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -662,10 +662,15 @@ const translations = {
   'mobilityPlatform.info.ecoCounter': 'Laskentapisteet keräävät tietoa liikenteestä mittaamalla eri liikennemuotojen käyttäjien määriä valituissa kohteissa. Tiedot on toimittanut Turun kaupunki käyttöluvan CC BY 4.0 nojalla.',
   'mobilityPlatform.info.bicycleStands': 'Turun kaupungin ylläpitämät polkupyöräpysäköintipaikat käsittävät kolmentyyppisiä pyörätelineitä: katetut ja runkolukittavat pyörätelineet, runkolukittavat pyörätelineet ja rengastelineelliset, ei runkolukittavat pyörätelineet.',
   'mobilityPlatform.info.gasFillingStations': 'Turun alueen julkiset kaasutankkausasemat. Tankkausasemien tiedot perustuvat Fintrafficin ylläpitämän liikennetilanne (https://liikennetilanne.fintraffic.fi) -sivuston tietoihin.',
-  'mobilityPlatform.info.rentalCars': 'Yhteiskäyttöautot ovat vapaasti vuokrattavia autoja. Kartalla näytetään tällä hetkellä vapaana olevat autot. Tiedot niistä tulevat 24Rent Oy:lta.',
+  'mobilityPlatform.info.rentalCars': 'Yhteiskäyttöautot ovat vapaasti vuokrattavia autoja. Kartalla näytetään tällä hetkellä vapaana olevat autot. Tiedot niistä tulevat 24Rent:lta.',
   'mobilityPlatform.info.parkingSpaces': 'Kartalla näkyvät Turun julkiset pysäköintialueet. Punainen väri parkkialueen kohdalla tarkoittaa, että se on jo lähes täynnä. Tarkat lukumäärät vapaista paikoista näet klikkaamalla parkkialuetta kartalla.  Tiedot pysäköintialueista tulevat Turun parkkihubista.',
   'mobilityPlatform.info.chargingStations': 'Turun alueen julkiset autojen sähkölatauspisteet. Latauspistetiedot perustuvat 05/2022 tehtyyn kartoitukseen.',
-  'mobilityPlatform.info.parkingChargeZones': 'Turun kaupungin pysäköinnin maksuvyöhykkeet.',
+  'mobilityPlatform.info.parkingChargeZones.paragraph.1': 'Turussa on käytössä kolme eri vyöhykettä, joilla on eri tuntimaksut.',
+  'mobilityPlatform.info.parkingChargeZones.paragraph.2': '3. vyöhyke on voimassa 2. vyöhykkeen rajojen, sekä kaupungin rajojen välisellä alueella.',
+  'mobilityPlatform.info.parkingChargeZones.paragraph.3': 'Maksullisuus määräytyy kuitenkin aina voimassa olevien liikennemerkkien mukaisesti ja koskee Turun kaupungin katutilaa ja kaupungin omia alueita, kuten kauppahallia ja kaupungintaloa.',
+  'mobilityPlatform.info.parkingChargeZones.zone.1': 'Ensimmäinen vyöhyke (ydinkeskusta-alue): 3,00 €/tunti',
+  'mobilityPlatform.info.parkingChargeZones.zone.2': 'Toinen vyöhyke : 1,50 €/tunti',
+  'mobilityPlatform.info.parkingChargeZones.zone.3': 'Kolmas vyöhyke: 0,60 €/tunti',
 
   // Bicycle routes
   'mobilityPlatform.menu.bicycleRoutes.euroVelo': 'EuroVelo 10 on eurooppalainen Suomen rannikkoa seuraava polkupyöräreitti. Helsingin ja Turun välisellä matkalla reitti on merkitty opastein.',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -660,10 +660,15 @@ const translations = {
   'mobilityPlatform.info.ecoCounter': 'Beräkningspunkter samlar in trafikdata genom att mäta antalet användare i olika lägen på utvalda destinationer. Informationen har tillhandahållits av Åbo stad under licensen CC BY 4.0.',
   'mobilityPlatform.info.bicycleStands': 'De cykelparkeringar som Åbo stad underhåller består av tre typer av cykelställ: täckta och ramlåsbara cykelställ, ramlåsbara cykelställ och däckställ, icke-ramlåsbara cykelställ.',
   'mobilityPlatform.info.gasFillingStations': 'Offentliga gastankstationer i Åboområdet. Informationen om gastankstationerna baseras på information som hämtas från webbplatsen om trafikläget https://liikennetilanne.fintraffic.fi,  som underhålls av Fintraffic.',
-  'mobilityPlatform.info.rentalCars': 'Bilpool bilarna är hyrbilar. Kartan visar lediga bilar. Informationen om bilarna kommer från 24Rent Ab.',
+  'mobilityPlatform.info.rentalCars': 'Bilpool bilarna är hyrbilar. Kartan visar lediga bilar. Informationen om bilarna kommer från 24Rent.',
   'mobilityPlatform.info.parkingSpaces': 'Kartan visar Åbos allmänna parkeringsområden. Den röda färgen bredvid en parkeringsplats betyder att den är nästan full. För att se det exakta antalet lediga platser, klicka på parkeringsområdet på kartan.  Informationen om parkeringsområden kommer från Åbo parkeringscentral.',
   'mobilityPlatform.info.chargingStations': 'Åboområdets allmänna billaddningsplatser. Informationen om laddningsplatser baserar sig på en kartläggning som gjordes 05/2022.',
-  'mobilityPlatform.info.parkingChargeZones': 'Parkeringsavgiftszoner av Åbo.',
+  'mobilityPlatform.info.parkingChargeZones.paragraph.1': 'I Åbo finns tre olika zoner, som har olika timavgift för parkering.',
+  'mobilityPlatform.info.parkingChargeZones.paragraph.2': 'Zon 3 omfattar området mellan gränserna för zon 2 och stadens gränser.',
+  'mobilityPlatform.info.parkingChargeZones.paragraph.3': 'Avgiften bestäms dock alltid av de gällande trafikskyltarna och gäller Åbo gator och stadens egna områden, t.ex. marknadshuset och stadshuset.',
+  'mobilityPlatform.info.parkingChargeZones.zone.1': 'Zon ett (kärncentrum): 3,00 €/timme',
+  'mobilityPlatform.info.parkingChargeZones.zone.2': 'Zon två: 1,50 €/timme',
+  'mobilityPlatform.info.parkingChargeZones.zone.3': 'Zon tre: 0,60€/timme',
 
   // Bicycle routes
   'mobilityPlatform.menu.bicycleRoutes.euroVelo': 'EuroVelo 10 är en europeisk cykelrutt som följer den finländska kusten. Sträckan mellan Helsingfors och Åbo är skyltad.',

--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -21,6 +21,7 @@ import TitleBar from '../../components/TitleBar';
 import InfoTextBox from '../../components/MobilityPlatform/InfoTextBox';
 import Description from './components/Description';
 import RouteLength from './components/RouteLength';
+import ExtendedInfo from './components/ExtendedInfo';
 
 const MobilitySettingsView = ({ classes, intl }) => {
   const [openWalkSettings, setOpenWalkSettings] = useState(false);
@@ -586,6 +587,17 @@ const MobilitySettingsView = ({ classes, intl }) => {
     </>
   );
 
+  const chargeZoneTranslations = {
+    message1: 'mobilityPlatform.info.parkingChargeZones.paragraph.1',
+    message2: 'mobilityPlatform.info.parkingChargeZones.paragraph.2',
+    message3: 'mobilityPlatform.info.parkingChargeZones.paragraph.3',
+    zones: [
+      'mobilityPlatform.info.parkingChargeZones.zone.1',
+      'mobilityPlatform.info.parkingChargeZones.zone.2',
+      'mobilityPlatform.info.parkingChargeZones.zone.3',
+    ],
+  };
+
   return (
     <div className={classes.content}>
       <TitleBar
@@ -637,7 +649,7 @@ const MobilitySettingsView = ({ classes, intl }) => {
       {showChargingStations ? <InfoTextBox infoText="mobilityPlatform.info.chargingStations" /> : null}
       {showGasFillingStations ? <InfoTextBox infoText="mobilityPlatform.info.gasFillingStations" /> : null}
       {showParkingSpaces ? <InfoTextBox infoText="mobilityPlatform.info.parkingSpaces" /> : null}
-      {openParkingChargeZoneList ? <InfoTextBox infoText="mobilityPlatform.info.parkingChargeZones" /> : null}
+      {openParkingChargeZoneList ? <ExtendedInfo translations={chargeZoneTranslations} /> : null}
     </div>
   );
 };

--- a/src/views/MobilitySettingsView/components/ExtendedInfo/ExtendedInfo.js
+++ b/src/views/MobilitySettingsView/components/ExtendedInfo/ExtendedInfo.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Typography } from '@material-ui/core';
+
+const ExtendedInfo = ({ classes, intl, translations }) => {
+  const text = (message, props = {}) => (
+    <Typography
+      variant="body2"
+      aria-label={intl.formatMessage({
+        id: message,
+      })}
+      {...props}
+    >
+      {intl.formatMessage({
+        id: message,
+      })}
+    </Typography>
+  );
+
+  return (
+    <div className={classes.container}>
+      {text(translations.message1)}
+      <ul>
+        {translations.zones.map(item => (
+          <li key={item}>
+            {text(item)}
+          </li>
+        ))}
+      </ul>
+      {text(translations.message2, { className: classes.margin })}
+      {text(translations.message3)}
+    </div>
+  );
+};
+
+ExtendedInfo.propTypes = {
+  classes: PropTypes.objectOf(PropTypes.any).isRequired,
+  intl: PropTypes.objectOf(PropTypes.any).isRequired,
+  translations: PropTypes.objectOf(PropTypes.any),
+};
+
+ExtendedInfo.defaultProps = {
+  translations: {},
+};
+
+export default ExtendedInfo;

--- a/src/views/MobilitySettingsView/components/ExtendedInfo/index.js
+++ b/src/views/MobilitySettingsView/components/ExtendedInfo/index.js
@@ -1,0 +1,6 @@
+import { withStyles } from '@material-ui/core';
+import { injectIntl } from 'react-intl';
+import ExtendedInfo from './ExtendedInfo';
+import styles from './styles';
+
+export default withStyles(styles)(injectIntl(ExtendedInfo));

--- a/src/views/MobilitySettingsView/components/ExtendedInfo/styles.js
+++ b/src/views/MobilitySettingsView/components/ExtendedInfo/styles.js
@@ -1,0 +1,10 @@
+export default theme => ({
+  container: {
+    margin: theme.spacing(2),
+    textAlign: 'left',
+    paddingBottom: theme.spacing(2),
+  },
+  margin: {
+    marginBottom: theme.spacing(1),
+  },
+});


### PR DESCRIPTION
# Display extended info about parking charge zones
## Display extended info about parking charge zones. Update browserTests.

### Cards 175 and partly 173.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Display extended info about parking charge zones
 1. src/views/MobilitySettingsView/components/ExtendedInfo/ExtendedInfo.js
     * New component that will display extended info about parking charge zones.
   
 2. src/views/MobilitySettingsView/components/ExtendedInfo/index.js
     * Import, then export from index -file.
    
 3. src/views/MobilitySettingsView/components/ExtendedInfo/styles.js
     * Component styles.
     
 4. src/views/MobilitySettingsView/MobilitySettingsView.js
     * Import ExtendedInfo and create translations object.
   
 5. src/i18n/en.js & src/i18n/fi.js & src/i18n/sv.js
     * Add new texts/translations.
    
 6. browserTests/browserTest.js
      * Comment out test that tested transit/bus stops since we don't display those on the map.

 6. browserTests/unitPageTest.js
      * Change unit id.