### PR TITLE
Fix/large font styles

### DIFF
--- a/server/ieMiddleware.js
+++ b/server/ieMiddleware.js
@@ -49,7 +49,7 @@ const styles = () => ({
   container: {
     margin: '5%',
     fontFamily: 'Lato',
-    fontSize: '1.125rem',
+    fontSize: 18,
     lineHeight: '1.125rem',
   },
   row: {
@@ -64,7 +64,7 @@ const styles = () => ({
   errorIcon: {
     alignSelf: 'center',
     color: 'rgb(25, 100, 230)',
-    fontSize: '2rem',
+    fontSize: 32,
     marginRight: 24,
   }
 })

--- a/server/ieMiddleware.js
+++ b/server/ieMiddleware.js
@@ -49,7 +49,7 @@ const styles = () => ({
   container: {
     margin: '5%',
     fontFamily: 'Lato',
-    fontSize: 18,
+    fontSize: '1.125rem',
     lineHeight: '18px',
   },
   row: {
@@ -64,7 +64,7 @@ const styles = () => ({
   errorIcon: {
     alignSelf: 'center',
     color: 'rgb(25, 100, 230)',
-    fontSize: 32,
+    fontSize: '2rem',
     marginRight: 24,
   }
 })

--- a/server/ieMiddleware.js
+++ b/server/ieMiddleware.js
@@ -50,7 +50,7 @@ const styles = () => ({
     margin: '5%',
     fontFamily: 'Lato',
     fontSize: '1.125rem',
-    lineHeight: '18px',
+    lineHeight: '1.125rem',
   },
   row: {
     display: 'flex',

--- a/src/components/AddressSearchBar/styles.js
+++ b/src/components/AddressSearchBar/styles.js
@@ -10,7 +10,7 @@ const styles = theme => ({
     backgroundColor: '#fff',
   },
   clearButton: {
-    fontSize: 22,
+    fontSize: '1.375rem',
   },
   divider: {
     width: 1,
@@ -23,7 +23,7 @@ const styles = theme => ({
   },
   searchIcon: {
     color: 'rgba(0, 0, 0, 0.54)',
-    fontSize: 22,
+    fontSize: '1.375rem',
     padding: theme.spacing(1),
   },
 });

--- a/src/components/AlertBox/styles.js
+++ b/src/components/AlertBox/styles.js
@@ -12,7 +12,7 @@ export default theme => ({
     height: 32,
   },
   cancelIcon: {
-    fontSize: 16,
+    fontSize: '1rem',
   },
   textContent: {
     textAlign: 'left',
@@ -28,7 +28,7 @@ export default theme => ({
   },
   closeButton: {
     textTransform: 'initial',
-    fontSize: 12,
+    fontSize: '0.75rem',
     position: 'absolute',
     top: 0,
     right: 0,

--- a/src/components/BackButton/styles.js
+++ b/src/components/BackButton/styles.js
@@ -7,7 +7,7 @@ export default theme => ({
   },
   containerText: {
     color: 'inherit',
-    fontSize: 14,
+    fontSize: '0.875rem',
     paddingLeft: theme.spacing(1),
   },
 });

--- a/src/components/CloseButton/styles.js
+++ b/src/components/CloseButton/styles.js
@@ -1,7 +1,7 @@
 export default ({
   button: {
     textTransform: 'none',
-    fontSize: 12,
+    fontSize: '0.75rem',
   },
   buttonLabel: {
     display: 'flex',

--- a/src/components/DropDownMenuButton/styles.js
+++ b/src/components/DropDownMenuButton/styles.js
@@ -37,7 +37,7 @@ export default theme => ({
   },
   iconRight: {
     marginLeft: 'auto',
-    fontSize: 24,
+    fontSize: '1.5rem',
   },
   menuItem: {
     padding: theme.spacing(1),

--- a/src/components/ExpandedSuggestions/styles.js
+++ b/src/components/ExpandedSuggestions/styles.js
@@ -47,7 +47,7 @@ export default theme => ({
     padding: theme.spacing(0.5),
     textTransform: 'none',
     '& svg': {
-      fontSize: 28,
+      fontSize: '1.75rem',
     },
   },
   iconButtonSearchLabel: {

--- a/src/components/FocusableSRLinks/styles.js
+++ b/src/components/FocusableSRLinks/styles.js
@@ -16,7 +16,7 @@ export default theme => ({
     color: '#2228af',
     cursor: 'pointer',
     display: 'inline-block',
-    fontSize: '14px',
+    fontSize: '0.875rem',
     lineHeight: '20px',
     margin: '8px 12px',
     minHeight: '32px',

--- a/src/components/FocusableSRLinks/styles.js
+++ b/src/components/FocusableSRLinks/styles.js
@@ -17,7 +17,7 @@ export default theme => ({
     cursor: 'pointer',
     display: 'inline-block',
     fontSize: '0.875rem',
-    lineHeight: '20px',
+    lineHeight: '1.25rem',
     margin: '8px 12px',
     minHeight: '32px',
     textDecoration: 'underline',

--- a/src/components/ListItems/DistrictItem/styles.js
+++ b/src/components/ListItems/DistrictItem/styles.js
@@ -18,7 +18,7 @@ export default theme => ({
     fontWeight: 'bold',
   },
   areaIcon: {
-    fontSize: 20,
+    fontSize: '1.25rem',
     marginLeft: 0,
     marginRight: theme.spacing(2),
   },

--- a/src/components/ListItems/SuggestionItem/styles.js
+++ b/src/components/ListItems/SuggestionItem/styles.js
@@ -14,7 +14,7 @@ export default theme => ({
     marginRight: theme.spacing(2),
     whiteSpace: 'pre-line',
     '& p': {
-      lineHeight: '18px',
+      lineHeight: '1.125rem',
     },
   },
   listIcon: {
@@ -38,7 +38,7 @@ export default theme => ({
   subtitle: {
     fontSize: '0.625rem',
     fontWeight: 'none',
-    lineHeight: '18px',
+    lineHeight: '1.125rem',
   },
   divider: {
     marginLeft: theme.spacing(8),

--- a/src/components/ListItems/SuggestionItem/styles.js
+++ b/src/components/ListItems/SuggestionItem/styles.js
@@ -36,7 +36,7 @@ export default theme => ({
     padding: theme.spacing(1),
   },
   subtitle: {
-    fontSize: '10px',
+    fontSize: '0.625rem',
     fontWeight: 'none',
     lineHeight: '18px',
   },

--- a/src/components/PaginationComponent/styles.js
+++ b/src/components/PaginationComponent/styles.js
@@ -2,7 +2,7 @@
 // Styles
 export default theme => ({
   arrowIcon: {
-    fontSize: 18,
+    fontSize: '1.125rem',
   },
   arrowFlip: {
     transform: 'scaleX(-1)',

--- a/src/components/PaperButton/styles.js
+++ b/src/components/PaperButton/styles.js
@@ -58,7 +58,7 @@ export default theme => ({
   },
   text: {
     textTransform: 'none',
-    lineHeight: '18px',
+    lineHeight: '1.125rem',
     color: 'rgba(0, 0, 0, 0.87)',
   },
   noBorder: {

--- a/src/components/ResultOrderer/styles.js
+++ b/src/components/ResultOrderer/styles.js
@@ -25,7 +25,7 @@ export default theme => ({
   select: {
     color: 'inherit',
     flex: '1 0 auto',
-    fontSize: 12,
+    fontSize: '0.75rem',
     lineHeight: `${15}px`,
     marginTop: 0,
     '&:before': {

--- a/src/components/SMAccordion/styles.js
+++ b/src/components/SMAccordion/styles.js
@@ -14,7 +14,7 @@ export default theme => ({
     alignItems: 'center',
   },
   icon: {
-    fontSize: 24,
+    fontSize: '1.5rem',
     transition: '0.3s',
     marginLeft: 'auto',
     color: theme.palette.primary.main,

--- a/src/components/SMIcon/styles.js
+++ b/src/components/SMIcon/styles.js
@@ -4,6 +4,6 @@ export default theme => ({
     display: 'inline-block',
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),
-    fontSize: 24,
+    fontSize: '1.5rem',
   },
 });

--- a/src/components/SearchBar/styles.js
+++ b/src/components/SearchBar/styles.js
@@ -96,7 +96,7 @@ export default theme => ({
     padding: theme.spacing(0.5, 0),
     textTransform: 'none',
     '& svg': {
-      fontSize: 28,
+      fontSize: '1.75rem',
     },
   },
   searchButtonFocus: {
@@ -175,7 +175,7 @@ export default theme => ({
   },
   cancelButton: {
     '& svg': {
-      fontSize: 14,
+      fontSize: '0.875rem',
     },
   },
   closeButton: {

--- a/src/components/SearchBar/styles.js
+++ b/src/components/SearchBar/styles.js
@@ -135,7 +135,7 @@ export default theme => ({
     paddingLeft: '18px',
   },
   subtitleText: {
-    lineHeight: '32px',
+    lineHeight: '2rem',
   },
   expandTitle: {
     alignSelf: 'center',

--- a/src/components/ServiceMapButton/styles.js
+++ b/src/components/ServiceMapButton/styles.js
@@ -54,6 +54,6 @@ export default theme => ({
     },
   },
   typography: {
-    fontSize: 14,
+    fontSize: '0.875rem',
   },
 });

--- a/src/components/Settings/styles.js
+++ b/src/components/Settings/styles.js
@@ -24,7 +24,7 @@ export default theme => ({
   },
   button: {
     textTransform: 'none',
-    fontSize: 12,
+    fontSize: '0.75rem',
   },
   buttonLabel: {
     display: 'flex',
@@ -119,7 +119,7 @@ export default theme => ({
     background: theme.palette.background.main,
   },
   pageTitleText: {
-    fontSize: 18,
+    fontSize: '1.125rem',
     color: '#fff',
   },
   radioGroup: {

--- a/src/components/SettingsInfo/styles.js
+++ b/src/components/SettingsInfo/styles.js
@@ -17,7 +17,7 @@ export default theme => ({
   },
   infoItemText: {
     fontSize: '0.688rem',
-    lineHeight: '13px',
+    lineHeight: '0.813rem',
   },
   settingsLink: {
     justifyContent: 'left',

--- a/src/components/SettingsInfo/styles.js
+++ b/src/components/SettingsInfo/styles.js
@@ -16,7 +16,7 @@ export default theme => ({
     padding: theme.spacing(1, 2),
   },
   infoItemText: {
-    fontSize: 11,
+    fontSize: '0.688rem',
     lineHeight: '13px',
   },
   settingsLink: {

--- a/src/components/SettingsText/styles.js
+++ b/src/components/SettingsText/styles.js
@@ -25,7 +25,7 @@ export default theme => ({
     fontWeight: 'bold',
     lineHeight: '24px',
     textAlign: 'left',
-    fontSize: 14,
+    fontSize: '0.875rem',
   },
   textPlain: {
     display: '-webkit-box',

--- a/src/components/SettingsText/styles.js
+++ b/src/components/SettingsText/styles.js
@@ -18,7 +18,7 @@ export default theme => ({
   },
   textSmall: {
     ...theme.typography.caption,
-    lineHeight: '18px',
+    lineHeight: '1.125rem',
     color: 'inherit',
   },
   titlePlain: {

--- a/src/components/TabLists/styles.js
+++ b/src/components/TabLists/styles.js
@@ -39,6 +39,7 @@ export default theme => ({
     paddingTop: theme.spacing(3),
     paddingBottom: theme.spacing(3),
     fontSize: 'clamp(0.8rem, 1.8vw, 0.875rem)',
+    overflowWrap: 'anywhere',
   },
   mobileTabFont: {
     fontSize: '0.719rem',

--- a/src/components/TabLists/styles.js
+++ b/src/components/TabLists/styles.js
@@ -38,10 +38,10 @@ export default theme => ({
     paddingRight: 0,
     paddingTop: theme.spacing(3),
     paddingBottom: theme.spacing(3),
-    fontSize: 'clamp(13px, 1.8vw, 14px)',
+    fontSize: 'clamp(0.8rem, 1.8vw, 0.875rem)',
   },
   mobileTabFont: {
-    fontSize: 11.5,
+    fontSize: '0.719rem',
   },
   addressBar: {
     padding: theme.spacing(3),

--- a/src/components/TitleBar/styles.js
+++ b/src/components/TitleBar/styles.js
@@ -28,7 +28,7 @@ export default theme => ({
     display: 'flex',
   },
   title: {
-    fontSize: 18,
+    fontSize: '1.125rem',
     color: 'inherit',
     flex: '1 1 auto',
     textTransform: 'none',
@@ -39,7 +39,7 @@ export default theme => ({
     },
   },
   titleLarge: {
-    fontSize: 20,
+    fontSize: '1.25rem',
     fontWeight: 'bold',
   },
   iconButton: {
@@ -49,7 +49,7 @@ export default theme => ({
     padding: 0,
     margin: theme.spacing(1),
     marginTop: 0,
-    fontSize: 18,
+    fontSize: '1.125rem',
   },
   icon: {
     display: 'flex',
@@ -65,7 +65,7 @@ export default theme => ({
     color: '#000',
   },
   distance: {
-    fontSize: 16,
+    fontSize: '1rem',
     color: 'inherit',
     marginLeft: 'auto',
     paddingLeft: theme.spacing(1),

--- a/src/components/TopBar/DrawerMenu/styles.js
+++ b/src/components/TopBar/DrawerMenu/styles.js
@@ -38,7 +38,7 @@ const styles = () => ({
     backgroundColor: '#141823',
   },
   drawerButtonText: {
-    lineHeight: '18px',
+    lineHeight: '1.125rem',
     color: 'inherit',
   },
   drawerIcon: {

--- a/src/components/TopBar/styles.js
+++ b/src/components/TopBar/styles.js
@@ -72,7 +72,6 @@ const styles = theme => ({
       textAlign: 'left',
     },
     maxWidth: 350,
-    maxHeight: 58,
     flex: '0 1 auto',
     overflow: 'hidden',
     textOverflow: 'ellipsis',

--- a/src/components/TopBar/styles.js
+++ b/src/components/TopBar/styles.js
@@ -103,7 +103,8 @@ const styles = theme => ({
     zIndex: theme.zIndex.infront,
   },
   toolbarButtonPressed: {
-    width: 66,
+    display: 'inline-block',
+    width: '4.125rem',
     textTransform: 'none',
     backgroundColor: '#353638',
     color: '#fff',
@@ -114,7 +115,8 @@ const styles = theme => ({
     },
   },
   toolbarButton: {
-    width: 66,
+    display: 'inline-block',
+    width: '4.125rem',
     textTransform: 'none',
     color: '#000',
     marginLeft: 4,

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -117,7 +117,7 @@ const zIndex = {
 
 const typography = {
   useNextVariants: true,
-  fontSize: '1rem',
+  fontSize: 16,
   // Use the system font instead of the default Roboto font.
   fontFamily: [
     'Lato',

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -57,7 +57,7 @@ const overrides = theme => ({
   },
   MuiSvgIcon: {
     root: {
-      fontSize: 24,
+      fontSize: '1.5rem',
     },
   },
   PrivateSwitchBase: {
@@ -117,7 +117,7 @@ const zIndex = {
 
 const typography = {
   useNextVariants: true,
-  fontSize: 16,
+  fontSize: '1rem',
   // Use the system font instead of the default Roboto font.
   fontFamily: [
     'Lato',

--- a/src/views/AddressView/styles.js
+++ b/src/views/AddressView/styles.js
@@ -1,6 +1,6 @@
 export default theme => ({
   addressIcon: {
-    fontSize: 36,
+    fontSize: '2.25rem',
   },
   topArea: {
     backgroundColor: '#fff',
@@ -16,7 +16,7 @@ export default theme => ({
     marginRight: 12,
   },
   titleIcon: {
-    fontSize: 28,
+    fontSize: '1.75rem',
     height: 24,
     width: 24,
     marginLeft: 0,
@@ -59,7 +59,7 @@ export default theme => ({
     fontWeight: 'bold',
   },
   areaIcon: {
-    fontSize: 20,
+    fontSize: '1.25rem',
     marginLeft: 0,
     marginRight: theme.spacing(2),
   },

--- a/src/views/AreaView/styles.js
+++ b/src/views/AreaView/styles.js
@@ -98,7 +98,7 @@ const styles = theme => ({
     boxShadow: `0 0 0 4px ${theme.palette.focusBorder.main}`,
   },
   addressItem: {
-    fontSize: 24,
+    fontSize: '1.5rem',
   },
   areaTitle: {
     display: 'flex',
@@ -112,10 +112,10 @@ const styles = theme => ({
     paddingRight: theme.spacing(2),
   },
   addressIcon: {
-    fontSize: 24,
+    fontSize: '1.5rem',
   },
   selectedAddress: {
-    fontSize: 18,
+    fontSize: '1.125rem',
   },
   subdistrictContainer: {
     flexDirection: 'column',

--- a/src/views/EmbedderView/styles.js
+++ b/src/views/EmbedderView/styles.js
@@ -57,7 +57,7 @@ export default (theme) => {
       borderRadius: 2,
       color: '#191919',
       display: 'block',
-      fontSize: 14,
+      fontSize: '0.875rem',
       lineHeight: 1.42857143,
       margin: '0 0 10.5px',
       padding: 10,

--- a/src/views/FeedbackView/styles.js
+++ b/src/views/FeedbackView/styles.js
@@ -18,7 +18,7 @@ export default theme => ({
     padding: 0,
   },
   input: {
-    fontSize: 12,
+    fontSize: '0.75rem',
     lineHeight: '20px',
     padding: 10,
     paddingLeft: 14,
@@ -40,10 +40,10 @@ export default theme => ({
     color: `${theme.palette.warning.main}`,
   },
   errorIcon: {
-    fontSize: 16,
+    fontSize: '1rem',
   },
   errorText: {
-    fontSize: 12,
+    fontSize: '0.75rem',
     margin: 0,
   },
   errorField: {
@@ -62,12 +62,12 @@ export default theme => ({
     paddingTop: 16,
     paddingBottom: 14,
     paddingRight: 16,
-    fontSize: 14,
+    fontSize: '0.875rem',
     fontWeight: 'bold',
   },
   subtitle: {
     paddingLeft: 8,
-    fontSize: 12,
+    fontSize: '0.75rem',
   },
   checkbox: {
     display: 'flex',
@@ -118,7 +118,7 @@ export default theme => ({
     color: '#fff',
   },
   modalTitle: {
-    fontSize: 16,
+    fontSize: '1rem',
     fontWeight: 'bold',
     textAlign: 'center',
   },

--- a/src/views/FeedbackView/styles.js
+++ b/src/views/FeedbackView/styles.js
@@ -19,7 +19,7 @@ export default theme => ({
   },
   input: {
     fontSize: '0.75rem',
-    lineHeight: '20px',
+    lineHeight: '1.25rem',
     padding: 10,
     paddingLeft: 14,
     paddingRight: 14,

--- a/src/views/InfoView/styles.js
+++ b/src/views/InfoView/styles.js
@@ -9,7 +9,7 @@ const styles = theme => ({
     textAlign: 'left',
     '& h3': {
       fontWeight: 'bold',
-      fontSize: 17,
+      fontSize: '1.063rem',
       padding: theme.spacing(2),
       paddingBottom: theme.spacing(1),
     },
@@ -32,7 +32,7 @@ const styles = theme => ({
   linkButton: {
     padding: theme.spacing(2),
     paddingTop: 0,
-    fontSize: 16,
+    fontSize: '1rem',
     color: theme.palette.link.main,
     textDecoration: 'underline',
   },

--- a/src/views/MapView/styles.js
+++ b/src/views/MapView/styles.js
@@ -174,7 +174,7 @@ const styles = theme => ({
   },
   innerCircle: {
     fontFamily: 'Lato',
-    fontSize: 20,
+    fontSize: '1.25rem',
     fontWeight: 'bold',
     color: '#fff',
     background: 'rgba(0, 22, 183)',
@@ -234,7 +234,7 @@ const styles = theme => ({
     maxHeight: '25vh',
     '& .popup-distance': {
       fontWeight: 'normal',
-      fontSize: '14px',
+      fontSize: '0.875rem',
     },
     '& li': {
       display: 'flex',
@@ -286,7 +286,7 @@ const styles = theme => ({
     fontWeight: 'bold',
   },
   addressIcon: {
-    fontSize: 50,
+    fontSize: '3.125rem',
     color: theme.palette.primary.main,
     textShadow: '-1px 0 #fff, 0 1px #fff, 1px 0 #fff, 0 -1px #fff',
     outline: 'none',
@@ -299,7 +299,7 @@ const styles = theme => ({
     color: '#fff',
     position: 'absolute',
     zIndex: theme.zIndex.behind,
-    fontSize: 16,
+    fontSize: '1rem',
     top: 16,
     left: 16,
   },
@@ -349,7 +349,7 @@ const styles = theme => ({
     paddingRight: theme.spacing(2),
   },
   eventDate: {
-    fontSize: 12,
+    fontSize: '0.75rem',
   },
 
   // Transit stops
@@ -369,7 +369,7 @@ const styles = theme => ({
     textShadow: '-1px 0 #fff, 0 1px #fff, 1px 0 #fff, 0 -1px #fff',
   },
   infoIcon: {
-    fontSize: 18,
+    fontSize: '1.125rem',
     width: 18,
     height: 18,
     lineHeight: '21px',
@@ -398,7 +398,7 @@ const styles = theme => ({
   },
   departureTime: {
     width: '15%',
-    fontSize: 13,
+    fontSize: '0.813rem',
   },
   departureVehicle: {
     width: '38%',
@@ -409,7 +409,7 @@ const styles = theme => ({
     fontWeight: 'bold',
   },
   routeName: {
-    fontSize: 12,
+    fontSize: '0.75rem',
     width: '55%',
     overflow: 'hidden',
     whiteSpace: 'nowrap',
@@ -419,7 +419,7 @@ const styles = theme => ({
     marginLeft: 'auto',
   },
   closeText: {
-    fontSize: 12,
+    fontSize: '0.75rem',
     color: 'rgba(0,0,0,0.6)',
   },
   busIconColor: {

--- a/src/views/ServiceTreeView/styles.js
+++ b/src/views/ServiceTreeView/styles.js
@@ -32,7 +32,7 @@ export default theme => ({
   },
   text: {
     fontSize: '0.938rem',
-    lineHeight: '18px',
+    lineHeight: '1.125rem',
   },
   iconRight: {
     marginLeft: 'auto',

--- a/src/views/ServiceTreeView/styles.js
+++ b/src/views/ServiceTreeView/styles.js
@@ -31,13 +31,13 @@ export default theme => ({
     backgroundColor: '#f5f5f5',
   },
   text: {
-    fontSize: '15px',
+    fontSize: '0.938rem',
     lineHeight: '18px',
   },
   iconRight: {
     marginLeft: 'auto',
     marginRight: theme.spacing(2),
-    fontSize: 30,
+    fontSize: '1.875rem',
   },
   checkBox: {
     width: 40,
@@ -79,12 +79,12 @@ export default theme => ({
     marginBottom: theme.spacing(1),
   },
   selectionText: {
-    fontSize: 12,
+    fontSize: '0.75rem',
     paddingRight: theme.spacing(2),
     color: '#fff',
   },
   deleteText: {
-    fontSize: 12,
+    fontSize: '0.75rem',
     paddingRight: theme.spacing(1),
     color: '#fff',
   },

--- a/src/views/UnitView/components/SocialMediaLinks/styles.js
+++ b/src/views/UnitView/components/SocialMediaLinks/styles.js
@@ -29,7 +29,7 @@ export default theme => ({
   },
   itemText: {
     color: '#2242C7',
-    fontSize: 14,
+    fontSize: '0.875rem',
   },
   defaultIcon: {
     height: 25,

--- a/src/views/UnitView/styles/styles.js
+++ b/src/views/UnitView/styles/styles.js
@@ -32,7 +32,7 @@ export default theme => ({
     padding: 10,
   },
   icon: {
-    fontSize: 24,
+    fontSize: '1.5rem',
     margin: 0,
   },
   eventIcon: {
@@ -88,7 +88,7 @@ export default theme => ({
   imageCaption: {
     width: '100%',
     minHeight: 31,
-    fontSize: 12,
+    fontSize: '0.75rem',
     lineHeight: '15px',
     position: 'absolute',
     display: 'flex',


### PR DESCRIPTION
# Improves styles when large font sizes are used

## Fixed containers that would break with large font sizes. Changing browser font size did not scale those texts that had font size as px. Changed these to use rem values. Changed some line height values from px to rem as well.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Convert font sizes from px to rem
 1. src/components/AddressSearchBar/styles.js
     * Change font size into rem. Rest of the changes are similar.
     
#### Convert line heights from px to rem
 1. src/components/PaperButton/styles.js
     * Change line height into rem. Rest of the changes are similar.
   
#### Fix incorrect mobile styles
 1. src/components/TopBar/styles.js
     * Fix to container that would break with large font sizes.
