### PR TITLE
Remove hide prefix function

### DIFF
--- a/src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/BicycleStandContent.js
+++ b/src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/BicycleStandContent.js
@@ -5,12 +5,6 @@ import { Typography } from '@mui/material';
 const BicycleStandContent = ({
   classes, bicycleStand, intl,
 }) => {
-  // Hides pyöräpysäköinti prefix
-  const renderName = (name) => {
-    const splitted = name.split(' ').slice(1);
-    return splitted.join(' ');
-  };
-
   const messageIds = {
     model: 'mobilityPlatform.content.bicycleStands.model',
     places: 'mobilityPlatform.content.bicycleStands.numOfPlaces',
@@ -25,7 +19,7 @@ const BicycleStandContent = ({
   const titleTypo = () => (
     <div className={classes.title}>
       <Typography variant="subtitle1" className={classes.titleText}>
-        {renderName(bicycleStand.name)}
+        {bicycleStand.name}
       </Typography>
     </div>
   );

--- a/src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/__tests__/BicycleStandContent.test.js
+++ b/src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/__tests__/BicycleStandContent.test.js
@@ -47,7 +47,9 @@ describe('<BicycleStandContent />', () => {
   it('does show text correctly', () => {
     const { container } = renderWithProviders(<BicycleStandContent {...mockProps} />);
 
+    const h6 = container.querySelector('h6');
     const p = container.querySelectorAll('p');
+    expect(h6.textContent).toContain(mockProps.bicycleStand.name);
     expect(p[0].textContent).toContain(
       `${finnishTranslations['mobilityPlatform.content.bicycleStands.model']}: ${mockProps.bicycleStand.extra.model}`,
     );

--- a/src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/__tests__/__snapshots__/BicycleStandContent.test.js.snap
+++ b/src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/__tests__/__snapshots__/BicycleStandContent.test.js.snap
@@ -8,7 +8,9 @@ exports[`<BicycleStandContent /> should work 1`] = `
     >
       <h6
         class="MuiTypography-root MuiTypography-subtitle1 injectIntl(BicycleStandContent)-titleText-2 css-dlbwt1-MuiTypography-root"
-      />
+      >
+        Testinimi
+      </h6>
     </div>
     <div>
       <div


### PR DESCRIPTION
# Remove hide prefix function

## Bicycle stands don't have prefix (Polkupyöräpysäköinti) in front of the name anymore. Function that hid said prefix has been removed.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Remove hide prefix function
 1. src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/BicycleStandContent.js
     * Removed hacky function that hid the prefix from the bicycle stand's name. Data doesn't contain said prefix anymore.
   
 2. src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/__tests__/BicycleStandContent.test.js
     * Update test case.
    
 3. src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/__tests__/__snapshots__/BicycleStandContent.test.js.snap
     * Update snapshot
