### PR TITLE
Add date range icon

### DIFF
--- a/src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
+++ b/src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { ButtonBase, Typography } from '@mui/material';
+import DateRangeIcon from '@mui/icons-material/DateRange';
 import { ReactSVG } from 'react-svg';
 import { DayPickerSingleDateController } from 'react-dates';
 import 'react-dates/initialize';
@@ -441,6 +442,9 @@ const EcoCounterContent = ({
           {renderStationName(stationName)}
         </Typography>
         <div className={classes.headerDate}>
+          <div className={classes.iconContainer}>
+            <DateRangeIcon />
+          </div>
           {!isDatePickerOpen ? (
             <ButtonBase className={classes.buttonTransparent} onClick={() => setIsDatePickerOpen(true)}>
               <Typography component="h5" className={classes.headerSubtitle}>

--- a/src/components/EcoCounter/EcoCounterContent/styles.js
+++ b/src/components/EcoCounter/EcoCounterContent/styles.js
@@ -48,6 +48,9 @@ const styles = {
   },
   headerDate: {
     marginLeft: 'auto',
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
   },
   ecocounterDatePicker: {
     position: 'absolute',
@@ -99,6 +102,10 @@ const styles = {
   },
   ecocounterChart: {
     margin: 0,
+  },
+  iconContainer: {
+    marginRight: '0.3rem',
+    paddingTop: '0.6rem',
   },
 };
 


### PR DESCRIPTION
# Improve date picker's visual look

## DatePicker -button looked too much like a plain text and not an interactive element. Placing calendar icon next to it was suggested to make it stand out more.

### Card 199

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Add date range icon
 1. src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
     * Add material-ui DateRange icon next to the ButtonBase that is used to open/close the DatePicker -element. It should look more interactive now.
   
 2. src/components/EcoCounter/EcoCounterContent/styles.js
     * Add few new styles.
    