### PR TITLE
Add injectFirst into StyledEngineProvider

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -68,7 +68,7 @@ class App extends React.Component {
     const intlData = LocaleUtility.intlData(locale);
 
     return (
-      <StyledEngineProvider>
+      <StyledEngineProvider injectFirst>
         <ThemeWrapper>
           <IntlProvider {...intlData}>
             <MetaTags />


### PR DESCRIPTION
# Add injectFirst into StyledEngineProvider

## Add injectFirst into StyledEngineProvider. This could fix styles being broken on server when migrating to Material-UI v5.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Add injectFirst into StyledEngineProvider
 1. src/App.js
     * injectFirst property should ensure styles are loaded correctly when migrating into v5.
   