### PR TITLE
Accessibility/navigation landmarks

### DIFF
--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -232,43 +232,45 @@ const TopBar = (props) => {
         <AppBar className={classes.appBar}>
           {/* Toolbar black area */}
           <Toolbar className={toolbarBlackClass}>
-            <div className={classes.toolbarBlackContainer}>
-              <ButtonBase
-                role="link"
-                aria-current={isHomePage ? 'page' : false}
-                onClick={() => handleNavigation('home')}
-                focusVisibleClassName={classes.topButtonFocused}
-              >
-                <Typography
-                  className={fontClass}
-                  color="inherit"
-                  variant="body2"
+            <nav>
+              <div className={classes.toolbarBlackContainer}>
+                <ButtonBase
+                  role="link"
+                  aria-current={isHomePage ? 'page' : false}
+                  onClick={() => handleNavigation('home')}
+                  focusVisibleClassName={classes.topButtonFocused}
                 >
-                  <FormattedMessage id="general.frontPage" />
+                  <Typography
+                    className={fontClass}
+                    color="inherit"
+                    variant="body2"
+                  >
+                    <FormattedMessage id="general.frontPage" />
+                  </Typography>
+                </ButtonBase>
+                <Typography aria-hidden color="inherit">
+                  |
                 </Typography>
-              </ButtonBase>
-              <Typography aria-hidden color="inherit">
-                |
-              </Typography>
-              {renderLanguages(pageType)}
-              <Typography aria-hidden color="inherit">
-                |
-              </Typography>
-              <ButtonBase
-                role="button"
-                onClick={() => handleContrastChange()}
-                focusVisibleClassName={classes.topButtonFocused}
-                aria-label={contrastAriaLabel}
-              >
-                <Typography
-                  className={fontClass}
-                  color="inherit"
-                  variant="body2"
+                {renderLanguages(pageType)}
+                <Typography aria-hidden color="inherit">
+                  |
+                </Typography>
+                <ButtonBase
+                  role="button"
+                  onClick={() => handleContrastChange()}
+                  focusVisibleClassName={classes.topButtonFocused}
+                  aria-label={contrastAriaLabel}
                 >
-                  <FormattedMessage id="general.contrast" />
-                </Typography>
-              </ButtonBase>
-            </div>
+                  <Typography
+                    className={fontClass}
+                    color="inherit"
+                    variant="body2"
+                  >
+                    <FormattedMessage id="general.contrast" />
+                  </Typography>
+                </ButtonBase>
+              </div>
+            </nav>
           </Toolbar>
 
           {/* Toolbar white area */}
@@ -289,23 +291,25 @@ const TopBar = (props) => {
               {renderDrawerMenu(pageType)}
             </MobileComponent>
             <DesktopComponent>
-              {!smallScreen ? (
-                <>
-                  <div className={classes.settingsButtonsContainer}>
-                    <Typography component="h2" style={visuallyHidden}>
-                      <FormattedMessage id="settings" />
-                    </Typography>
-                    {renderSettingsButtons()}
-                  </div>
-                </>
-              ) : (
-                <>
-                  <div className={classes.mobileButtonContainer}>
-                    {renderMenuButton()}
-                  </div>
-                  {renderDrawerMenu(pageType)}
-                </>
-              )}
+              <nav>
+                {!smallScreen ? (
+                  <>
+                    <div className={classes.settingsButtonsContainer}>
+                      <Typography component="h2" style={visuallyHidden}>
+                        <FormattedMessage id="settings" />
+                      </Typography>
+                      {renderSettingsButtons()}
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className={classes.mobileButtonContainer}>
+                      {renderMenuButton()}
+                    </div>
+                    {renderDrawerMenu(pageType)}
+                  </>
+                )}
+              </nav>
               {!smallScreen && <ToolMenu />}
             </DesktopComponent>
           </Toolbar>

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -1,27 +1,23 @@
-import React, { useState } from 'react';
-import PropTypes from 'prop-types';
-import {
-  Button,
-  Typography,
-  AppBar,
-  Toolbar,
-  ButtonBase,
-} from '@mui/material';
 import { Map } from '@mui/icons-material';
+import {
+  AppBar, Button, ButtonBase, Toolbar, Typography,
+} from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom/cjs/react-router-dom.min';
-import DrawerMenu from './DrawerMenu';
+import paths from '../../../config/paths';
+import { focusToViewTitle } from '../../utils/accessibility';
+import { useNavigationParams } from '../../utils/address';
+import LocaleUtility from '../../utils/locale';
 import DesktopComponent from '../DesktopComponent';
 import MobileComponent from '../MobileComponent';
 import ToolMenu from '../ToolMenu';
-import { focusToViewTitle } from '../../utils/accessibility';
-import LocaleUtility from '../../utils/locale';
-import { useNavigationParams } from '../../utils/address';
-import SettingsButton from './SettingsButton';
+import DrawerMenu from './DrawerMenu';
 import MenuButton from './MenuButton';
-import paths from '../../../config/paths';
+import SettingsButton from './SettingsButton';
 import SMLogo from './SMLogo';
 
 const TopBar = (props) => {
@@ -232,7 +228,7 @@ const TopBar = (props) => {
         <AppBar className={classes.appBar}>
           {/* Toolbar black area */}
           <Toolbar className={toolbarBlackClass}>
-            <nav>
+            <nav aria-label={intl.formatMessage({ id: 'app.navigation.language' })}>
               <div className={classes.toolbarBlackContainer}>
                 <ButtonBase
                   role="link"
@@ -291,7 +287,7 @@ const TopBar = (props) => {
               {renderDrawerMenu(pageType)}
             </MobileComponent>
             <DesktopComponent>
-              <nav>
+              <nav aria-label={intl.formatMessage({ id: 'app.navigation.settings' })} className={classes.settingsButtonsContainer}>
                 {!smallScreen ? (
                   <>
                     <div className={classes.settingsButtonsContainer}>

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -5,6 +5,9 @@ const translations = {
   'app.description': 'Find services near your home',
   'app.og.image.alt': 'Servicemap logo',
   'app.errorpage.title': 'Error message page',
+  'app.navigation.language': 'Language and contrast',
+  'app.navigation.home': 'Home',
+  'app.navigation.settings': 'Settings',
 
   // Accessibility
   'accessibility': 'Accessibility',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -5,6 +5,9 @@ const translations = {
   'app.description': 'Pääkaupunkiseudun kaikki julkiset palvelut ulottuvillasi.',
   'app.og.image.alt': 'Palvelukartan logo',
   'app.errorpage.title': 'Virheviestisivu',
+  'app.navigation.language': 'Kieli ja kontrasti',
+  'app.navigation.home': 'Koti',
+  'app.navigation.settings': 'Asetukset',
 
   // Accessibility
   'accessibility': 'Esteettömyys',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -5,6 +5,9 @@ const translations = {
   'app.description': 'Alla tjänster i huvudstadsregionen inom räckhåll.',
   'app.og.image.alt': 'Servicekarta logo',
   'app.errorpage.title': 'Felmeddelandesida',
+  'app.navigation.language': 'Språk och kontrast',
+  'app.navigation.home': 'Hem',
+  'app.navigation.settings': 'Inställningar',
 
   // Accessibility
   'accessibility': 'Tillgänglighet',

--- a/src/views/HomeView/HomeView.js
+++ b/src/views/HomeView/HomeView.js
@@ -8,14 +8,14 @@ import MobileComponent from '../../components/MobileComponent';
 import config from '../../../config';
 import NewsInfo from '../../components/NewsInfo';
 import { useNavigationParams } from '../../utils/address';
-import useLocaleText from '../../utils/useLocaleText';
+// import useLocaleText from '../../utils/useLocaleText';
 
 const HomeView = (props) => {
   const {
     classes, toggleSettings, navigator, userLocation,
   } = props;
 
-  const getLocaleText = useLocaleText();
+  // const getLocaleText = useLocaleText();
   const getAddressNavigatorParams = useNavigationParams();
 
   const renderNavigationOptions = () => {
@@ -35,68 +35,71 @@ const HomeView = (props) => {
     return (
       <div className={classes.background}>
         <div className={classes.buttonContainer}>
-          {areaSelection}
-          <PaperButton
-            messageID="home.buttons.closeByServices"
-            icon={getIcon('location')}
-            link
-            disabled={noUserLocation}
-            onClick={() => {
-              navigator.push('address', getAddressNavigatorParams(userLocation.addressData));
-            }}
-            subtitleID={subtitleID && subtitleID}
-          />
-          {/* Turku mobility platform settings */}
-          <PaperButton
-            messageID="home.buttons.mobilityPlatformSettings"
-            icon={getIcon('mobilityPlatformIcon')}
-            link
-            onClick={() => navigator.push('mobilityPlatform')}
-          />
-          <PaperButton
-            messageID="home.buttons.services"
-            icon={getIcon('serviceList')}
-            link
-            onClick={() => navigator.push('serviceTree')}
-          />
-          <MobileComponent>
+          <nav>
+            {areaSelection}
             <PaperButton
-              messageID="home.buttons.settings"
-              icon={getIcon('accessibility')}
+              messageID="home.buttons.closeByServices"
+              icon={getIcon('location')}
               link
-              onClick={() => toggleSettings('mobile')}
+              disabled={noUserLocation}
+              onClick={() => {
+                navigator.push('address', getAddressNavigatorParams(userLocation.addressData));
+              }}
+              subtitleID={subtitleID && subtitleID}
             />
-          </MobileComponent>
-          <PaperButton
-            messageID="home.send.feedback"
-            icon={getIcon('feedback')}
-            link
-            onClick={() => navigator.push('feedback')}
-          />
-          <PaperButton
-            id="home-paper-info-button"
-            messageID="info.title"
-            icon={getIcon('help')}
-            link
-            onClick={() => {
-              navigator.push('info', null, 'home-paper-info-button');
-            }}
-          />
-          <PaperButton
-            messageID="home.old.link"
-            newTab
-            icon={<Map />}
-            link
-            onClick={() => {
-              window.open(
-                getLocaleText({
-                  fi: config.oldMapFi,
-                  sv: config.oldMapSv,
-                  en: config.oldMapEn,
-                }),
-              );
-            }}
-          />
+            {/* Turku mobility platform settings */}
+            <PaperButton
+              messageID="home.buttons.mobilityPlatformSettings"
+              icon={getIcon('mobilityPlatformIcon')}
+              link
+              onClick={() => navigator.push('mobilityPlatform')}
+            />
+            <PaperButton
+              messageID="home.buttons.services"
+              icon={getIcon('serviceList')}
+              link
+              onClick={() => navigator.push('serviceTree')}
+            />
+            <MobileComponent>
+              <PaperButton
+                messageID="home.buttons.settings"
+                icon={getIcon('accessibility')}
+                link
+                onClick={() => toggleSettings('mobile')}
+              />
+            </MobileComponent>
+            <PaperButton
+              messageID="home.send.feedback"
+              icon={getIcon('feedback')}
+              link
+              onClick={() => navigator.push('feedback')}
+            />
+            <PaperButton
+              id="home-paper-info-button"
+              messageID="info.title"
+              icon={getIcon('help')}
+              link
+              onClick={() => {
+                navigator.push('info', null, 'home-paper-info-button');
+              }}
+            />
+            {/* Old map of Turku does not exist anymore. */}
+            {/* <PaperButton
+              messageID="home.old.link"
+              newTab
+              icon={<Map />}
+              link
+              onClick={() => {
+                window.open(
+                  getLocaleText({
+                    fi: config.oldMapFi,
+                    sv: config.oldMapSv,
+                    en: config.oldMapEn,
+                  }),
+                );
+              }}
+            /> */}
+          </nav>
           <NewsInfo showCount={2} />
         </div>
       </div>

--- a/src/views/HomeView/HomeView.js
+++ b/src/views/HomeView/HomeView.js
@@ -1,21 +1,21 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import { Map } from '@mui/icons-material';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useIntl } from 'react-intl';
+import config from '../../../config';
 import { SearchBar } from '../../components';
+import MobileComponent from '../../components/MobileComponent';
+import NewsInfo from '../../components/NewsInfo';
 import PaperButton from '../../components/PaperButton';
 import { getIcon } from '../../components/SMIcon';
-import MobileComponent from '../../components/MobileComponent';
-import config from '../../../config';
-import NewsInfo from '../../components/NewsInfo';
 import { useNavigationParams } from '../../utils/address';
-// import useLocaleText from '../../utils/useLocaleText';
 
 const HomeView = (props) => {
   const {
     classes, toggleSettings, navigator, userLocation,
   } = props;
 
-  // const getLocaleText = useLocaleText();
+  const { formatMessage } = useIntl();
   const getAddressNavigatorParams = useNavigationParams();
 
   const renderNavigationOptions = () => {
@@ -35,7 +35,7 @@ const HomeView = (props) => {
     return (
       <div className={classes.background}>
         <div className={classes.buttonContainer}>
-          <nav>
+          <nav aria-label={formatMessage({ id: 'app.navigation.home' })}>
             {areaSelection}
             <PaperButton
               messageID="home.buttons.closeByServices"


### PR DESCRIPTION
# Add navigation landmarks to top bar and home view

## Add navigation landmarks for top bar language selection, settings and home view navigation buttons.

### Eficode report page 23.
-----------------------------------------------------------------------------------------------
### Breakdown:

#### Add navigation landmarks to topbar and home view
 1. src/components/TopBar/TopBar.js
     * Wrap toolbars in nav -element.
   
 2. src/views/HomeView/HomeView.js
     * Wrap main menu in nav -element. Comment out button that directs user into the old map, because that url redirects back into current map.
     
#### Add navigation aria-labels
 1. src/components/TopBar/TopBar.js
     * Add aria-label into the nav -elements. Also add correct styles to it. Organize imports into proper order.
   
 2. src/views/HomeView/HomeView.js
     * Add aria-label into the nav -element. Organize imports.
    
 3. src/i18n/en.js & src/i18n/fi.js & src/i18n/sv.js
      * Add translations.
