### PR TITLE
Fix/remove style engine provider

### DIFF
--- a/server/createEmotionCache.js
+++ b/server/createEmotionCache.js
@@ -1,5 +1,5 @@
 import createCache from '@emotion/cache';
 
 export default function createEmotionCache() {
-  return createCache({ key: 'css' });
+  return createCache({ key: 'css', prepend: true });
 }

--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,6 @@ import withStyles from 'isomorphic-style-loader/withStyles';
 import {
   Switch, Route, BrowserRouter,
 } from 'react-router-dom';
-import { StyledEngineProvider } from '@mui/material';
 import styles from './index.css';
 import SMFonts from './service-map-icons.css';
 import HSLFonts from './hsl-icons.css';
@@ -68,24 +67,22 @@ class App extends React.Component {
     const intlData = LocaleUtility.intlData(locale);
 
     return (
-      <StyledEngineProvider>
-        <ThemeWrapper>
-          <IntlProvider {...intlData}>
-            <MetaTags />
-            {/* <StylesProvider generateClassName={generateClassName}> */}
-            <div className="App">
-              <Switch>
-                <Route path="*/embedder" component={EmbedderView} />
-                <Route path="*/embed" component={EmbedLayout} />
-                <Route render={() => <DefaultLayout />} />
-              </Switch>
-              <Navigator />
-              <DataFetcher />
-            </div>
-            {/* </StylesProvider> */}
-          </IntlProvider>
-        </ThemeWrapper>
-      </StyledEngineProvider>
+      <ThemeWrapper>
+        <IntlProvider {...intlData}>
+          <MetaTags />
+          {/* <StylesProvider generateClassName={generateClassName}> */}
+          <div className="App">
+            <Switch>
+              <Route path="*/embedder" component={EmbedderView} />
+              <Route path="*/embed" component={EmbedLayout} />
+              <Route render={() => <DefaultLayout />} />
+            </Switch>
+            <Navigator />
+            <DataFetcher />
+          </div>
+          {/* </StylesProvider> */}
+        </IntlProvider>
+      </ThemeWrapper>
     );
   }
 }


### PR DESCRIPTION
# Replace StyledEngineProvider with prepend value.

## Replace StyledEngineProvider with prepend value (true) inside emotion cache. This could fix style errors on the server.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Remove StyledEngineProvider and add prepend option to emotion cache
 1. server/createEmotionCache.js
     * Add prepend value to emotionCache.
   
 2. src/App.js
     * Remove StyleEngineProvider, because prepend value inside emotion cache does the same thing to the style injection order.
    