### PR TITLE
Display swedish map tiles

### DIFF
--- a/src/views/MapView/config/mapConfig.js
+++ b/src/views/MapView/config/mapConfig.js
@@ -134,15 +134,15 @@ const getMapOptions = (type, locale) => {
       if (isRetina) {
         suffix += '@2x';
       }
-      /* if (locale === 'sv') {
+      if (locale === 'sv') {
         suffix += '@sv';
-      } */
+      }
       break;
     }
     case 'accessible_map': {
-      /* if (locale === 'sv') {
+      if (locale === 'sv') {
         suffix += '@sv';
-      } */
+      }
       break;
     }
     default:


### PR DESCRIPTION
# Display Swedish map tiles

## Display Swedish map tiles, because tile server works again.

### Card 90

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Display Swedish map tiles
 1. src/views/MapView/config/mapConfig.js
     * Restore if statement that checks if locale is 'sv' and adds suffix on the map tiles.
   