### PR TITLE
Feature/add seasonal info

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,10 @@ REITTIOPAS_URL="https://reittiopas.foli.fi/reitti/"
 THEME_PKG=1
 MOBILITY_PLATFORM_API="https://palvelukartta-api.turku.fi"
 
+# City bikes and scooters are not in use during off-season.
+SEASON_END="2022-10-31"
+SEASON_START="2023-04-01"
+
 # COOKIEBOT_DATA_CBID is used as the data-cbid value of the Cookiebot script.
 # THEME_PKG must also be set to "1" or "true", ie. THEME_PKG=1.
 # COOKIEBOT_DATA_CBID='string containing the data_cbid value'

--- a/config/default.js
+++ b/config/default.js
@@ -243,4 +243,6 @@ export default {
   "matomoSiteId": settings.MATOMO_SITE_ID,
   "themePKG": settings.THEME_PKG,
   "mobilityPlatformAPI": settings.MOBILITY_PLATFORM_API,
+  "seasonEnd": settings.SEASON_END,
+  "seasonStart": settings.SEASON_START,
 }

--- a/server/server.js
+++ b/server/server.js
@@ -242,6 +242,8 @@ const htmlTemplate = (req, reactDom, preloadedState, css, cssString, locale, hel
         window.nodeEnvSettings.ECOCOUNTER_API = "${process.env.ECOCOUNTER_API}";
         window.nodeEnvSettings.THEME_PKG = "${process.env.THEME_PKG}";
         window.nodeEnvSettings.MOBILITY_PLATFORM_API = "${process.env.MOBILITY_PLATFORM_API}";
+        window.nodeEnvSettings.SEASON_END = "${process.env.SEASON_END}";
+        window.nodeEnvSettings.SEASON_START = "${process.env.SEASON_START}";
 
         window.appVersion = {};
         window.appVersion.tag = "${versionTag}";

--- a/src/components/MobilityPlatform/CityBikes/CityBikes.js
+++ b/src/components/MobilityPlatform/CityBikes/CityBikes.js
@@ -6,6 +6,7 @@ import follariIcon from 'servicemap-ui-turku/assets/icons/icons-icon_follari.svg
 import MobilityPlatformContext from '../../../context/MobilityPlatformContext';
 import { fetchCityBikesData } from '../mobilityPlatformRequests/mobilityPlatformRequests';
 import { isDataValid } from '../utils/utils';
+import config from '../../../../config';
 import CityBikesContent from './components/CityBikesContent';
 
 const CityBikes = () => {
@@ -15,9 +16,9 @@ const CityBikes = () => {
 
   const { openMobilityPlatform, showCityBikes } = useContext(MobilityPlatformContext);
 
-  const currentDate = moment().clone();
-  const seasonEndDate = '2022-10-31';
-  const seasonStartDate = '2023-04-01';
+  const currentDate = moment();
+  const seasonEndDate = config.seasonEnd;
+  const seasonStartDate = config.seasonStart;
   const isWinterSeason = currentDate.isAfter(seasonEndDate) && currentDate.isBefore(seasonStartDate);
 
   const map = useMap();

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -746,7 +746,7 @@ const translations = {
   'mobilityPlatform.info.cityBikes.subtitle': 'Read more:',
   'mobilityPlatform.info.cityBikes.link': 'https://www.foli.fi/en/f%C3%B6li-bikes',
   'mobilityPlatform.info.cityBikes.apiInfo': 'Map data comes from the Donkey Republic interface in real time.',
-  'mobilityPlatform.info.cityBikes.winterSeason': 'Talvikausi alkaa 1. marraskuuta ja päättyy 31. maaliskuuta. Silloin kaupunkipyörät eivät ole käytössä.', // TODO translate
+  'mobilityPlatform.info.cityBikes.winterSeason': 'Winter season begins on November 1st and ends on March 31st. During that time city bikes are not available.', // TODO verify
   'mobilityPlatform.info.guestHarbour': 'Turku Guest harbour is directly next to the city centre, on Läntinen Rantakatu 57. More information about e.g. booking of boat place can be found on',
   'mobilityPlatform.info.guestHarbour.link': 'www.turunvierasvenesatama.fi',
   'mobilityPlatform.info.marinas': 'City of Turku´s marina berths are located in Uittamo, Lauttaranta and Aura River. A berth can be reserved and paid either on the Varauspalvelu reservation service (in Finnish only) or at the customer service of the City of Turku (Puolalankatu 5). Boating season begins 1st of May and ends on 31st of October. Reservations open on January 31. On the Varauspalvelu reservation service you can browse available berths by harbour and by boat size. There are also winter storage places for boats in Lauttaranta. Boats can be stored for winter between September 1st and May 31st.',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -746,7 +746,7 @@ const translations = {
   'mobilityPlatform.info.cityBikes.subtitle': 'Read more:',
   'mobilityPlatform.info.cityBikes.link': 'https://www.foli.fi/en/f%C3%B6li-bikes',
   'mobilityPlatform.info.cityBikes.apiInfo': 'Map data comes from the Donkey Republic interface in real time.',
-  'mobilityPlatform.info.cityBikes.winterSeason': 'Winter season begins on November 1st and ends on March 31st. During that time city bikes are not available.', // TODO verify
+  'mobilityPlatform.info.cityBikes.winterSeason': 'Winter season begins on November 1st and ends on March 31st. During that time city bikes are not available.',
   'mobilityPlatform.info.guestHarbour': 'Turku Guest harbour is directly next to the city centre, on Läntinen Rantakatu 57. More information about e.g. booking of boat place can be found on',
   'mobilityPlatform.info.guestHarbour.link': 'www.turunvierasvenesatama.fi',
   'mobilityPlatform.info.marinas': 'City of Turku´s marina berths are located in Uittamo, Lauttaranta and Aura River. A berth can be reserved and paid either on the Varauspalvelu reservation service (in Finnish only) or at the customer service of the City of Turku (Puolalankatu 5). Boating season begins 1st of May and ends on 31st of October. Reservations open on January 31. On the Varauspalvelu reservation service you can browse available berths by harbour and by boat size. There are also winter storage places for boats in Lauttaranta. Boats can be stored for winter between September 1st and May 31st.',
@@ -762,7 +762,7 @@ const translations = {
   'mobilityPlatform.info.streetMaintenance.noActivity': 'There is no street maintenance work in progress during the selected time period.',
   'mobilityPlatform.info.streetMaintenance.general': 'Street maintenance includes ploughing and sanding of streets, cycle paths and structurally indistinguishable footpaths and cycle paths in winter and removing the sand in spring.',
   'mobilityPlatform.info.streetMaintenance.link': 'Winter maintenance rules.',
-  'mobilityPlatform.info.streetMaintenance.brushedRoads': 'Bicycle roads that are shown on the map are part of the intensified winter maintenance. Snow will be removed by brushing and salt solution or sand will be used to prevent slippery conditions.', // TODO verify
+  'mobilityPlatform.info.streetMaintenance.brushedRoads': 'Bicycle roads that are shown on the map are part of the intensified winter maintenance. Snow will be removed by brushing and salt solution or sand will be used to prevent slippery conditions.',
 
   // Bicycle routes
   'mobilityPlatform.menu.bicycleRoutes.euroVelo': 'The EuroVelo 10, is the European cycle route that stretches along the Finnish costal line. The distance between Helsinki and Turku has roadside directions for the route.',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -746,6 +746,7 @@ const translations = {
   'mobilityPlatform.info.cityBikes.subtitle': 'Read more:',
   'mobilityPlatform.info.cityBikes.link': 'https://www.foli.fi/en/f%C3%B6li-bikes',
   'mobilityPlatform.info.cityBikes.apiInfo': 'Map data comes from the Donkey Republic interface in real time.',
+  'mobilityPlatform.info.cityBikes.winterSeason': 'Talvikausi alkaa 1. marraskuuta ja päättyy 31. maaliskuuta. Silloin kaupunkipyörät eivät ole käytössä.', // TODO translate
   'mobilityPlatform.info.guestHarbour': 'Turku Guest harbour is directly next to the city centre, on Läntinen Rantakatu 57. More information about e.g. booking of boat place can be found on',
   'mobilityPlatform.info.guestHarbour.link': 'www.turunvierasvenesatama.fi',
   'mobilityPlatform.info.marinas': 'City of Turku´s marina berths are located in Uittamo, Lauttaranta and Aura River. A berth can be reserved and paid either on the Varauspalvelu reservation service (in Finnish only) or at the customer service of the City of Turku (Puolalankatu 5). Boating season begins 1st of May and ends on 31st of October. Reservations open on January 31. On the Varauspalvelu reservation service you can browse available berths by harbour and by boat size. There are also winter storage places for boats in Lauttaranta. Boats can be stored for winter between September 1st and May 31st.',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -739,7 +739,7 @@ const translations = {
   'mobilityPlatform.info.cityBikes.subtitle': 'Lue lisää kaupunkipyöristä:',
   'mobilityPlatform.info.cityBikes.link': 'https://foli.fi/föllärit',
   'mobilityPlatform.info.cityBikes.apiInfo': 'Kartan tiedot tulevat Donkey Republicin rajapinnasta reaaliajassa.',
-  'mobilityPlatform.info.cityBikes.winterSeason': 'Talvikausi alkaa 1. marraskuuta ja päättyy 31. maaliskuuta. Silloin kaupunkipyörät eivät ole käytössä.', // TODO verify
+  'mobilityPlatform.info.cityBikes.winterSeason': 'Talvikausi alkaa 1. marraskuuta ja päättyy 31. maaliskuuta. Silloin kaupunkipyörät eivät ole käytössä.',
   'mobilityPlatform.info.guestHarbour': 'Turun vierasvenesatama sijaitsee aivan keskustan kupeessa, osoitteessa Läntinen Rantakatu 57. Lisätietoja liittyen esimerkiksi venepaikan varaamiseen löytyy osoitteesta',
   'mobilityPlatform.info.guestHarbour.link': 'www.turunvierasvenesatama.fi',
   'mobilityPlatform.info.marinas': 'Turun kaupungilla on venepaikkoja Lauttarannassa, Uittamolla ja Aurajoessa.  Venepaikkoja voi varata ja maksaa Varauspalvelussa, jossa vapaita paikkoja voi selata satamittain ja myös veneen mittojen mukaan. Veneilykausi on 1.5 - 31.10. Venepaikkoja voi varata 31.1 alkaen. Lauttarannassa on lisäksi talvisäilytyspaikkoja. Talvisäilytysaika on 1.9 - 31.5.',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -739,6 +739,7 @@ const translations = {
   'mobilityPlatform.info.cityBikes.subtitle': 'Lue lisää kaupunkipyöristä:',
   'mobilityPlatform.info.cityBikes.link': 'https://foli.fi/föllärit',
   'mobilityPlatform.info.cityBikes.apiInfo': 'Kartan tiedot tulevat Donkey Republicin rajapinnasta reaaliajassa.',
+  'mobilityPlatform.info.cityBikes.winterSeason': 'Talvikausi alkaa 1. marraskuuta ja päättyy 31. maaliskuuta. Silloin kaupunkipyörät eivät ole käytössä.', // TODO verify
   'mobilityPlatform.info.guestHarbour': 'Turun vierasvenesatama sijaitsee aivan keskustan kupeessa, osoitteessa Läntinen Rantakatu 57. Lisätietoja liittyen esimerkiksi venepaikan varaamiseen löytyy osoitteesta',
   'mobilityPlatform.info.guestHarbour.link': 'www.turunvierasvenesatama.fi',
   'mobilityPlatform.info.marinas': 'Turun kaupungilla on venepaikkoja Lauttarannassa, Uittamolla ja Aurajoessa.  Venepaikkoja voi varata ja maksaa Varauspalvelussa, jossa vapaita paikkoja voi selata satamittain ja myös veneen mittojen mukaan. Veneilykausi on 1.5 - 31.10. Venepaikkoja voi varata 31.1 alkaen. Lauttarannassa on lisäksi talvisäilytyspaikkoja. Talvisäilytysaika on 1.9 - 31.5.',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -747,6 +747,7 @@ const translations = {
   'mobilityPlatform.info.cityBikes.subtitle': 'Läs mer om stadscyklar:',
   'mobilityPlatform.info.cityBikes.link': 'https://www.foli.fi/sv/fölicyklar',
   'mobilityPlatform.info.cityBikes.apiInfo': 'Informationen om cyklarna kommer från Donkey Rebuplic i realtid.',
+  'mobilityPlatform.info.cityBikes.winterSeason': 'Talvikausi alkaa 1. marraskuuta ja päättyy 31. maaliskuuta. Silloin kaupunkipyörät eivät ole käytössä.', // TODO translate
   'mobilityPlatform.info.guestHarbour': 'Turku Gästhamn ligger precis intill centrum, på Västra Strandgatan 57. Mer information t.ex. om bokning av båtplats finns på',
   'mobilityPlatform.info.guestHarbour.link': 'www.turunvierasvenesatama.fi',
   'mobilityPlatform.info.marinas': 'Åbo stad har båtplatser vid Färjstranden, Uittamo och Aura å. Båtplatser kan bokas och betalas via Bokningstjänsten. Båtsäsongen börjar den 1 maj och slutar den 31 oktober. Båtplatser kan bokas från januari 31. Där går det att bläddra bland lediga platser efter hamn och båtens mått. Vid Färjstranden finns det också vinterförvaringsplatser. Båten kan laggas i vinterforvaring mellan september 1 och maj 31.',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -747,7 +747,7 @@ const translations = {
   'mobilityPlatform.info.cityBikes.subtitle': 'Läs mer om stadscyklar:',
   'mobilityPlatform.info.cityBikes.link': 'https://www.foli.fi/sv/fölicyklar',
   'mobilityPlatform.info.cityBikes.apiInfo': 'Informationen om cyklarna kommer från Donkey Rebuplic i realtid.',
-  'mobilityPlatform.info.cityBikes.winterSeason': 'Talvikausi alkaa 1. marraskuuta ja päättyy 31. maaliskuuta. Silloin kaupunkipyörät eivät ole käytössä.', // TODO translate
+  'mobilityPlatform.info.cityBikes.winterSeason': 'Vintersäsongen börjar den 1 november och slutar den 31 mars. Då är stadscyklarna inte i bruk.',
   'mobilityPlatform.info.guestHarbour': 'Turku Gästhamn ligger precis intill centrum, på Västra Strandgatan 57. Mer information t.ex. om bokning av båtplats finns på',
   'mobilityPlatform.info.guestHarbour.link': 'www.turunvierasvenesatama.fi',
   'mobilityPlatform.info.marinas': 'Åbo stad har båtplatser vid Färjstranden, Uittamo och Aura å. Båtplatser kan bokas och betalas via Bokningstjänsten. Båtsäsongen börjar den 1 maj och slutar den 31 oktober. Båtplatser kan bokas från januari 31. Där går det att bläddra bland lediga platser efter hamn och båtens mått. Vid Färjstranden finns det också vinterförvaringsplatser. Båten kan laggas i vinterforvaring mellan september 1 och maj 31.',

--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -1,6 +1,7 @@
 import {
   Checkbox, FormControl, FormControlLabel, FormGroup, Typography,
 } from '@material-ui/core';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, {
   useContext, useEffect, useMemo, useRef, useState,
@@ -10,17 +11,17 @@ import iconBicycle from 'servicemap-ui-turku/assets/icons/icons-icon_bicycle.svg
 import iconBoat from 'servicemap-ui-turku/assets/icons/icons-icon_boating.svg';
 import iconCar from 'servicemap-ui-turku/assets/icons/icons-icon_car.svg';
 import iconScooter from 'servicemap-ui-turku/assets/icons/icons-icon_scooter.svg';
-import iconWalk from 'servicemap-ui-turku/assets/icons/icons-icon_walk.svg';
 import iconSnowplow from 'servicemap-ui-turku/assets/icons/icons-icon_street_maintenance.svg';
+import iconWalk from 'servicemap-ui-turku/assets/icons/icons-icon_walk.svg';
 import InfoTextBox from '../../components/MobilityPlatform/InfoTextBox';
 import {
   fetchBicycleRouteNames,
   fetchCultureRouteNames,
   fetchMobilityMapPolygonData,
 } from '../../components/MobilityPlatform/mobilityPlatformRequests/mobilityPlatformRequests';
-import useLocaleText from '../../utils/useLocaleText';
 import TitleBar from '../../components/TitleBar';
 import MobilityPlatformContext from '../../context/MobilityPlatformContext';
+import useLocaleText from '../../utils/useLocaleText';
 import ButtonMain from './components/ButtonMain';
 import CityBikeInfo from './components/CityBikeInfo';
 import Description from './components/Description';
@@ -118,12 +119,19 @@ const MobilitySettingsView = ({ classes, intl }) => {
   const locale = useSelector(state => state.user.locale);
   const getLocaleText = useLocaleText();
 
+  const currentDate = moment().clone();
+  const seasonEndDate = '2022-10-31';
+  const seasonStartDate = '2023-04-01';
+  const isWinterSeason = currentDate.isAfter(seasonEndDate) && currentDate.isBefore(seasonStartDate);
+
   const bikeInfo = {
     paragraph1: 'mobilityPlatform.info.cityBikes.paragraph.1',
     paragraph2: 'mobilityPlatform.info.cityBikes.paragraph.2',
     subtitle: 'mobilityPlatform.info.cityBikes.subtitle',
     link: 'mobilityPlatform.info.cityBikes.link',
     apiInfo: 'mobilityPlatform.info.cityBikes.apiInfo',
+    isWinterSeason,
+    seasonInfo: 'mobilityPlatform.info.cityBikes.winterSeason',
     url: {
       fi: 'https://foli.fi/föllärit',
       en: 'https://www.foli.fi/en/f%C3%B6li-bikes',

--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -19,6 +19,7 @@ import {
   fetchCultureRouteNames,
   fetchMobilityMapPolygonData,
 } from '../../components/MobilityPlatform/mobilityPlatformRequests/mobilityPlatformRequests';
+import config from '../../../config';
 import TitleBar from '../../components/TitleBar';
 import MobilityPlatformContext from '../../context/MobilityPlatformContext';
 import useLocaleText from '../../utils/useLocaleText';
@@ -119,9 +120,9 @@ const MobilitySettingsView = ({ classes, intl }) => {
   const locale = useSelector(state => state.user.locale);
   const getLocaleText = useLocaleText();
 
-  const currentDate = moment().clone();
-  const seasonEndDate = '2022-10-31';
-  const seasonStartDate = '2023-04-01';
+  const currentDate = moment();
+  const seasonEndDate = config.seasonEnd;
+  const seasonStartDate = config.seasonStart;
   const isWinterSeason = currentDate.isAfter(seasonEndDate) && currentDate.isBefore(seasonStartDate);
 
   const bikeInfo = {

--- a/src/views/MobilitySettingsView/components/CityBikeInfo/CityBikeInfo.js
+++ b/src/views/MobilitySettingsView/components/CityBikeInfo/CityBikeInfo.js
@@ -1,23 +1,12 @@
 import { Link, Typography } from '@material-ui/core';
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import React from 'react';
+import useLocaleText from '../../../../utils/useLocaleText';
 
 const CityBikeInfo = ({
   classes, intl, bikeInfo,
 }) => {
-  const [url, setUrl] = useState(bikeInfo.url.fi);
-
-  const locale = useSelector(state => state.user.locale);
-
-  useEffect(() => {
-    if (locale === 'en') {
-      setUrl(bikeInfo.url.en);
-    }
-    if (locale === 'sv') {
-      setUrl(bikeInfo.url.sv);
-    }
-  }, [locale]);
+  const getLocaleText = useLocaleText();
 
   const text = textValue => (
     <Typography
@@ -35,10 +24,11 @@ const CityBikeInfo = ({
 
   return (
     <div className={classes.container}>
+      {bikeInfo.isWinterSeason ? text(bikeInfo.seasonInfo) : null}
       {text(bikeInfo.paragraph1)}
       {text(bikeInfo.paragraph2)}
       {text(bikeInfo.subtitle)}
-      <Link target="_blank" href={url}>
+      <Link target="_blank" href={getLocaleText(bikeInfo.url)}>
         {text(bikeInfo.link)}
       </Link>
       {text(bikeInfo.apiInfo)}

--- a/src/views/MobilitySettingsView/components/CityBikeInfo/CityBikeInfo.js
+++ b/src/views/MobilitySettingsView/components/CityBikeInfo/CityBikeInfo.js
@@ -8,10 +8,10 @@ const CityBikeInfo = ({
 }) => {
   const getLocaleText = useLocaleText();
 
-  const text = textValue => (
+  const text = (textValue, isBold) => (
     <Typography
       variant="body2"
-      className={classes.margin}
+      className={isBold ? `${classes.margin} ${classes.bold}` : classes.margin}
       aria-label={intl.formatMessage({
         id: textValue,
       })}
@@ -24,7 +24,7 @@ const CityBikeInfo = ({
 
   return (
     <div className={classes.container}>
-      {bikeInfo.isWinterSeason ? text(bikeInfo.seasonInfo) : null}
+      {bikeInfo.isWinterSeason ? text(bikeInfo.seasonInfo, true) : null}
       {text(bikeInfo.paragraph1)}
       {text(bikeInfo.paragraph2)}
       {text(bikeInfo.subtitle)}

--- a/src/views/MobilitySettingsView/components/CityBikeInfo/__tests__/CityBikeInfo.test.js
+++ b/src/views/MobilitySettingsView/components/CityBikeInfo/__tests__/CityBikeInfo.test.js
@@ -13,6 +13,8 @@ const mockProps = {
     subtitle: 'mobilityPlatform.info.cityBikes.subtitle',
     link: 'mobilityPlatform.info.cityBikes.link',
     apiInfo: 'mobilityPlatform.info.cityBikes.apiInfo',
+    isWinterSeason: true,
+    seasonInfo: 'mobilityPlatform.info.cityBikes.winterSeason',
     url: {
       fi: 'https://foli.fi/föllärit',
       en: 'https://www.foli.fi/en/f%C3%B6li-bikes',
@@ -36,21 +38,23 @@ describe('<CityBikeInfo />', () => {
 
     const p = container.querySelectorAll('p');
     const link = container.querySelector('a');
-    expect(p[0].textContent).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.paragraph.1']);
-    expect(p[1].textContent).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.paragraph.2']);
-    expect(p[2].textContent).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.subtitle']);
+    expect(p[0].textContent).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.winterSeason']);
+    expect(p[1].textContent).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.paragraph.1']);
+    expect(p[2].textContent).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.paragraph.2']);
+    expect(p[3].textContent).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.subtitle']);
     expect(link.textContent).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.link']);
-    expect(p[4].textContent).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.apiInfo']);
+    expect(p[5].textContent).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.apiInfo']);
   });
 
   it('does contain aria-label attributes', () => {
     const { container } = renderWithProviders(<CityBikeInfo {...mockProps} />);
 
     const p = container.querySelectorAll('p');
-    expect(p[0].getAttribute('aria-label')).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.paragraph.1']);
-    expect(p[1].getAttribute('aria-label')).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.paragraph.2']);
-    expect(p[2].getAttribute('aria-label')).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.subtitle']);
-    expect(p[3].getAttribute('aria-label')).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.link']);
-    expect(p[4].getAttribute('aria-label')).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.apiInfo']);
+    expect(p[0].getAttribute('aria-label')).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.winterSeason']);
+    expect(p[1].getAttribute('aria-label')).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.paragraph.1']);
+    expect(p[2].getAttribute('aria-label')).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.paragraph.2']);
+    expect(p[3].getAttribute('aria-label')).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.subtitle']);
+    expect(p[4].getAttribute('aria-label')).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.link']);
+    expect(p[5].getAttribute('aria-label')).toContain(finnishTranslations['mobilityPlatform.info.cityBikes.apiInfo']);
   });
 });

--- a/src/views/MobilitySettingsView/components/CityBikeInfo/__tests__/__snapshots__/CityBikeInfo.test.js.snap
+++ b/src/views/MobilitySettingsView/components/CityBikeInfo/__tests__/__snapshots__/CityBikeInfo.test.js.snap
@@ -6,6 +6,12 @@ exports[`<CityBikeInfo /> should work 1`] = `
     class="injectIntl(CityBikeInfo)-container-1"
   >
     <p
+      aria-label="Talvikausi alkaa 1. marraskuuta ja päättyy 31. maaliskuuta. Silloin kaupunkipyörät eivät ole käytössä."
+      class="MuiTypography-root injectIntl(CityBikeInfo)-margin-2 MuiTypography-body2"
+    >
+      Talvikausi alkaa 1. marraskuuta ja päättyy 31. maaliskuuta. Silloin kaupunkipyörät eivät ole käytössä.
+    </p>
+    <p
       aria-label="Turun kaupunkipyörät eli tuttavallisemmin föllärit, ovat pyöriä, joita kuka vaan voi vuokrata Donkey Republicin sovelluksella.  Föllärin voi vuokrata kertamaksulla, kuukausimaksulla tai koko kesän kattavalla kausimaksulla."
       class="MuiTypography-root injectIntl(CityBikeInfo)-margin-2 MuiTypography-body2"
     >

--- a/src/views/MobilitySettingsView/components/CityBikeInfo/__tests__/__snapshots__/CityBikeInfo.test.js.snap
+++ b/src/views/MobilitySettingsView/components/CityBikeInfo/__tests__/__snapshots__/CityBikeInfo.test.js.snap
@@ -7,7 +7,7 @@ exports[`<CityBikeInfo /> should work 1`] = `
   >
     <p
       aria-label="Talvikausi alkaa 1. marraskuuta ja päättyy 31. maaliskuuta. Silloin kaupunkipyörät eivät ole käytössä."
-      class="MuiTypography-root injectIntl(CityBikeInfo)-margin-2 MuiTypography-body2"
+      class="MuiTypography-root injectIntl(CityBikeInfo)-margin-2 injectIntl(CityBikeInfo)-bold-3 MuiTypography-body2"
     >
       Talvikausi alkaa 1. marraskuuta ja päättyy 31. maaliskuuta. Silloin kaupunkipyörät eivät ole käytössä.
     </p>

--- a/src/views/MobilitySettingsView/components/CityBikeInfo/styles.js
+++ b/src/views/MobilitySettingsView/components/CityBikeInfo/styles.js
@@ -7,6 +7,9 @@ const styles = theme => ({
   margin: {
     marginBottom: theme.spacing(1),
   },
+  bold: {
+    fontWeight: 'bold',
+  },
 });
 
 export default styles;


### PR DESCRIPTION
# Show info about the off season

## Show info text about the off (winter) season, when city bikes are unavailable

### Card 236

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Render city bikes only outside of winter season
 1. src/components/MobilityPlatform/CityBikes/CityBikes.js
     * Cleanup code and add dateTime value to determine when winter season begins and city bikes are not in use. Render city bike markers only when they are available.
   
 2. src/views/MobilitySettingsView/components/CityBikeInfo/CityBikeInfo.js
     * Render bold text only when it is winter season.
    
 3. src/views/MobilitySettingsView/components/CityBikeInfo/__tests__/CityBikeInfo.test.js
     * Update tests.

 4. src/i18n/fi.js & src/i18n/en.js & src/i18n/sv.js
     * Add new translation