### PR TITLE
Fix/mobility settings mobile view

### DIFF
--- a/src/views/MobilitySettingsView/components/FormLabel/FormLabel.js
+++ b/src/views/MobilitySettingsView/components/FormLabel/FormLabel.js
@@ -1,54 +1,61 @@
 import { FormControlLabel, Switch, Typography } from '@material-ui/core';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
  * Render 1 or more switches inside form.
-   * @property {any} classes
-   * @property {any} intl
-   * @property {string} keyVal
-   * @property {string} msgId
-   * @property {boolean} checkedValue
-   * @property {Function} onChangeValue
-   * @return {JSX Element}
-   */
+ * @property {any} classes
+ * @property {any} intl
+ * @property {string} keyVal
+ * @property {string} msgId
+ * @property {boolean} checkedValue
+ * @property {Function} onChangeValue
+ * @return {JSX Element}
+ */
 
 const FormLabel = ({
   classes, intl, msgId, checkedValue, onChangeValue,
-}) => (
-  <FormControlLabel
-    label={(
-      <Typography
-        variant="body2"
-        aria-label={intl.formatMessage({
-          id: msgId,
-        })}
-      >
-        {intl.formatMessage({
-          id: msgId,
-        })}
-      </Typography>
-      )}
-    control={(
-      <Switch
-        checked={checkedValue}
-        role="switch"
-        inputProps={{
-          'aria-label': intl.formatMessage({
+}) => {
+  const useMobileStatus = () => useMediaQuery('(max-width:360px)');
+
+  const isNarrow = useMobileStatus();
+
+  return (
+    <FormControlLabel
+      label={(
+        <Typography
+          variant="body2"
+          aria-label={intl.formatMessage({
             id: msgId,
-          }),
-        }}
-        onChange={onChangeValue}
-        onKeyPress={(event) => {
-          if (event.key === 'Enter') {
-            onChangeValue();
-          }
-        }}
-      />
+          })}
+        >
+          {intl.formatMessage({
+            id: msgId,
+          })}
+        </Typography>
       )}
-    className={classes.formLabel}
-  />
-);
+      control={(
+        <Switch
+          checked={checkedValue}
+          role="switch"
+          inputProps={{
+            'aria-label': intl.formatMessage({
+              id: msgId,
+            }),
+          }}
+          onChange={onChangeValue}
+          onKeyPress={(event) => {
+            if (event.key === 'Enter') {
+              onChangeValue();
+            }
+          }}
+        />
+      )}
+      className={`${classes.formLabel} ${isNarrow ? classes.paddingSm : classes.paddingMd}`}
+    />
+  );
+};
 
 FormLabel.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,

--- a/src/views/MobilitySettingsView/components/FormLabel/FormLabel.js
+++ b/src/views/MobilitySettingsView/components/FormLabel/FormLabel.js
@@ -1,5 +1,4 @@
 import { FormControlLabel, Switch, Typography } from '@material-ui/core';
-import useMediaQuery from '@material-ui/core/useMediaQuery';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -16,46 +15,40 @@ import React from 'react';
 
 const FormLabel = ({
   classes, intl, msgId, checkedValue, onChangeValue,
-}) => {
-  const useMobileStatus = () => useMediaQuery('(max-width:360px)');
-
-  const isNarrow = useMobileStatus();
-
-  return (
-    <FormControlLabel
-      label={(
-        <Typography
-          variant="body2"
-          aria-label={intl.formatMessage({
-            id: msgId,
-          })}
-        >
-          {intl.formatMessage({
-            id: msgId,
-          })}
-        </Typography>
+}) => (
+  <FormControlLabel
+    label={(
+      <Typography
+        variant="body2"
+        aria-label={intl.formatMessage({
+          id: msgId,
+        })}
+      >
+        {intl.formatMessage({
+          id: msgId,
+        })}
+      </Typography>
       )}
-      control={(
-        <Switch
-          checked={checkedValue}
-          role="switch"
-          inputProps={{
-            'aria-label': intl.formatMessage({
-              id: msgId,
-            }),
-          }}
-          onChange={onChangeValue}
-          onKeyPress={(event) => {
-            if (event.key === 'Enter') {
-              onChangeValue();
-            }
-          }}
-        />
+    control={(
+      <Switch
+        checked={checkedValue}
+        role="switch"
+        inputProps={{
+          'aria-label': intl.formatMessage({
+            id: msgId,
+          }),
+        }}
+        onChange={onChangeValue}
+        onKeyPress={(event) => {
+          if (event.key === 'Enter') {
+            onChangeValue();
+          }
+        }}
+      />
       )}
-      className={`${classes.formLabel} ${isNarrow ? classes.paddingSm : classes.paddingMd}`}
-    />
-  );
-};
+    className={classes.formLabel}
+  />
+);
 
 FormLabel.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,

--- a/src/views/MobilitySettingsView/components/FormLabel/FormLabel.js
+++ b/src/views/MobilitySettingsView/components/FormLabel/FormLabel.js
@@ -1,4 +1,5 @@
 import { FormControlLabel, Switch, Typography } from '@material-ui/core';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -15,40 +16,46 @@ import React from 'react';
 
 const FormLabel = ({
   classes, intl, msgId, checkedValue, onChangeValue,
-}) => (
-  <FormControlLabel
-    label={(
-      <Typography
-        variant="body2"
-        aria-label={intl.formatMessage({
-          id: msgId,
-        })}
-      >
-        {intl.formatMessage({
-          id: msgId,
-        })}
-      </Typography>
-      )}
-    control={(
-      <Switch
-        checked={checkedValue}
-        role="switch"
-        inputProps={{
-          'aria-label': intl.formatMessage({
+}) => {
+  const useMobileStatus = () => useMediaQuery('(max-width:360px)');
+
+  const isNarrow = useMobileStatus();
+
+  return (
+    <FormControlLabel
+      label={(
+        <Typography
+          variant="body2"
+          aria-label={intl.formatMessage({
             id: msgId,
-          }),
-        }}
-        onChange={onChangeValue}
-        onKeyPress={(event) => {
-          if (event.key === 'Enter') {
-            onChangeValue();
-          }
-        }}
-      />
+          })}
+        >
+          {intl.formatMessage({
+            id: msgId,
+          })}
+        </Typography>
       )}
-    className={classes.formLabel}
-  />
-);
+      control={(
+        <Switch
+          checked={checkedValue}
+          role="switch"
+          inputProps={{
+            'aria-label': intl.formatMessage({
+              id: msgId,
+            }),
+          }}
+          onChange={onChangeValue}
+          onKeyPress={(event) => {
+            if (event.key === 'Enter') {
+              onChangeValue();
+            }
+          }}
+        />
+      )}
+      className={`${classes.formLabel} ${isNarrow ? classes.paddingSm : classes.paddingMd}`}
+    />
+  );
+};
 
 FormLabel.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,

--- a/src/views/MobilitySettingsView/components/FormLabel/__tests__/__snapshots__/FormLabel.test.js.snap
+++ b/src/views/MobilitySettingsView/components/FormLabel/__tests__/__snapshots__/FormLabel.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<FormLabel /> should work 1`] = `
 <div>
   <label
-    class="MuiFormControlLabel-root injectIntl(FormLabel)-formLabel-3"
+    class="MuiFormControlLabel-root injectIntl(FormLabel)-formLabel-1 injectIntl(FormLabel)-paddingMd-2"
   >
     <span
       class="MuiSwitch-root"

--- a/src/views/MobilitySettingsView/components/FormLabel/__tests__/__snapshots__/FormLabel.test.js.snap
+++ b/src/views/MobilitySettingsView/components/FormLabel/__tests__/__snapshots__/FormLabel.test.js.snap
@@ -3,14 +3,14 @@
 exports[`<FormLabel /> should work 1`] = `
 <div>
   <label
-    class="MuiFormControlLabel-root injectIntl(FormLabel)-formLabel-1"
+    class="MuiFormControlLabel-root injectIntl(FormLabel)-formLabel-1 injectIntl(FormLabel)-paddingMd-2"
   >
     <span
       class="MuiSwitch-root"
     >
       <span
         aria-disabled="false"
-        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-4 MuiSwitch-switchBase MuiSwitch-colorSecondary"
         role="switch"
       >
         <span
@@ -18,7 +18,7 @@ exports[`<FormLabel /> should work 1`] = `
         >
           <input
             aria-label="Polkupyöräpysäköinti"
-            class="PrivateSwitchBase-input-5 MuiSwitch-input"
+            class="PrivateSwitchBase-input-7 MuiSwitch-input"
             type="checkbox"
             value=""
           />

--- a/src/views/MobilitySettingsView/components/FormLabel/__tests__/__snapshots__/FormLabel.test.js.snap
+++ b/src/views/MobilitySettingsView/components/FormLabel/__tests__/__snapshots__/FormLabel.test.js.snap
@@ -3,14 +3,14 @@
 exports[`<FormLabel /> should work 1`] = `
 <div>
   <label
-    class="MuiFormControlLabel-root injectIntl(FormLabel)-formLabel-1 injectIntl(FormLabel)-paddingMd-2"
+    class="MuiFormControlLabel-root injectIntl(FormLabel)-formLabel-1"
   >
     <span
       class="MuiSwitch-root"
     >
       <span
         aria-disabled="false"
-        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-4 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiSwitch-switchBase MuiSwitch-colorSecondary"
         role="switch"
       >
         <span
@@ -18,7 +18,7 @@ exports[`<FormLabel /> should work 1`] = `
         >
           <input
             aria-label="Polkupyöräpysäköinti"
-            class="PrivateSwitchBase-input-7 MuiSwitch-input"
+            class="PrivateSwitchBase-input-5 MuiSwitch-input"
             type="checkbox"
             value=""
           />

--- a/src/views/MobilitySettingsView/components/FormLabel/styles.js
+++ b/src/views/MobilitySettingsView/components/FormLabel/styles.js
@@ -2,13 +2,9 @@ const styles = {
   formLabel: {
     backgroundColor: 'rgba(70,72,75,255)',
     margin: '0',
-    color: '#fff',
-  },
-  paddingMd: {
     padding: '0.5rem 3rem',
-  },
-  paddingSm: {
-    padding: '0.5rem 0.8rem',
+    color: '#fff',
+    textAlign: 'left',
   },
 };
 

--- a/src/views/MobilitySettingsView/components/FormLabel/styles.js
+++ b/src/views/MobilitySettingsView/components/FormLabel/styles.js
@@ -2,9 +2,14 @@ const styles = {
   formLabel: {
     backgroundColor: 'rgba(70,72,75,255)',
     margin: '0',
-    padding: '0.5rem 3rem',
     color: '#fff',
     textAlign: 'left',
+  },
+  paddingMd: {
+    padding: '0.4rem 3rem',
+  },
+  paddingSm: {
+    padding: '0.4rem 1rem',
   },
 };
 

--- a/src/views/MobilitySettingsView/components/FormLabel/styles.js
+++ b/src/views/MobilitySettingsView/components/FormLabel/styles.js
@@ -1,15 +1,14 @@
 const styles = {
-  formControl: {
-    width: '100%',
-  },
-  formGroup: {
-    marginTop: '0',
-  },
   formLabel: {
-    padding: '0.4rem 3rem',
     backgroundColor: 'rgba(70,72,75,255)',
     margin: '0',
     color: '#fff',
+  },
+  paddingMd: {
+    padding: '0.5rem 3rem',
+  },
+  paddingSm: {
+    padding: '0.5rem 0.8rem',
   },
 };
 

--- a/src/views/MobilitySettingsView/components/FormLabel/styles.js
+++ b/src/views/MobilitySettingsView/components/FormLabel/styles.js
@@ -6,7 +6,7 @@ const styles = {
     marginTop: '0',
   },
   formLabel: {
-    padding: '0.4rem 3.5rem',
+    padding: '0.4rem 3rem',
     backgroundColor: 'rgba(70,72,75,255)',
     margin: '0',
     color: '#fff',

--- a/src/views/MobilitySettingsView/styles.js
+++ b/src/views/MobilitySettingsView/styles.js
@@ -4,6 +4,7 @@ const styles = theme => ({
   },
   container: {
     borderBottom: '1px solid rgba(0, 0, 0, 255)',
+    wordBreak: 'break-word',
   },
   buttonSmall: {
     width: '27%',


### PR DESCRIPTION
# Adjust text position and padding value

## Place label text of switch components into left and reduce padding when screen is narrow

### [Trello card #222](https://trello.com/c/grWf4n1w/222-teksti-sijoittuu-v%C3%A4%C3%A4rin-mobiilissa)
#### Other refs:
[Trello card #169](https://trello.com/c/oIBMV8XG/169-tekstit-mobiilissa-liikkumisn%C3%A4kym%C3%A4n-autoilun-listassa-eiv%C3%A4t-sijoitu-oikein)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Adjust padding values
 1. src/views/MobilitySettingsView/components/FormLabel/FormLabel.js
     * Use media query to check screen width and breakpoint to select correct padding values for narrow screens.
 
 2. src/views/MobilitySettingsView/components/FormLabel/styles.js
     * Add new styles and remove unused classes.
    