### PR TITLE
Feature/update ecocounter stations division

### DIFF
--- a/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
+++ b/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
@@ -67,11 +67,11 @@ const EcoCounterMarkers = ({ classes }) => {
 
   useEffect(() => {
     fitToMapBounds(showEcoCounter.walking, stationsWithPedestrians);
-  }, [showEcoCounter, stationsWithPedestrians]);
+  }, [showEcoCounter.walking, ecoCounterStations]);
 
   useEffect(() => {
     fitToMapBounds(showEcoCounter.cycling, ecoCounterStations);
-  }, [showEcoCounter, ecoCounterStations]);
+  }, [showEcoCounter.cycling, ecoCounterStations]);
 
   /**
    * Render markers on the map

--- a/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
+++ b/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { PropTypes } from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
 import { useMap } from 'react-leaflet';

--- a/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
+++ b/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
@@ -31,7 +31,20 @@ const EcoCounterMarkers = ({ classes }) => {
 
   const map = useMap();
 
-  const stationNames = ['Teatterisilta', 'Auransilta', 'Kirjastosilta', 'Teatteri ranta'];
+  const stationNames = (name) => {
+    switch (name) {
+      case 'Teatterisilta':
+        return true;
+      case 'Auransilta':
+        return true;
+      case 'Kirjastosilta':
+        return true;
+      case 'Teatteri ranta':
+        return true;
+      default:
+        return false;
+    }
+  };
 
   /**
    * Filter out stations that only show data about cycling
@@ -39,7 +52,7 @@ const EcoCounterMarkers = ({ classes }) => {
    * @returns array
    */
   const filterStations = data => data.reduce((acc, curr) => {
-    if (stationNames.includes(curr.name)) {
+    if (stationNames(curr.name)) {
       acc.push(curr);
     }
     return acc;

--- a/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
+++ b/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
@@ -31,6 +31,10 @@ const EcoCounterMarkers = ({ classes }) => {
 
   const map = useMap();
 
+  /** These stations contains data about pedestrians as well
+   * @param {string} name -name value is used to check if it matches or not
+   * @returns {boolean} -true or false value
+   */
   const stationNames = (name) => {
     switch (name) {
       case 'Teatterisilta':
@@ -48,8 +52,8 @@ const EcoCounterMarkers = ({ classes }) => {
 
   /**
    * Filter out stations that only show data about cycling
-   * @param {array} data
-   * @returns array
+   * @param {array} data -EcoCounter stations
+   * @returns {array} -Filtered data with only items that matched criteria
    */
   const filterStations = data => data.reduce((acc, curr) => {
     if (stationNames(curr.name)) {
@@ -66,8 +70,8 @@ const EcoCounterMarkers = ({ classes }) => {
 
   /**
    * Fit markers to map bounds
-   * @param {boolean} isValid
-   * @param {array} data
+   * @param {boolean} isValid -true if data is valid, otherwise false
+   * @param {array} data -EcoCounter stations
    */
   const fitToMapBounds = (isValid, data) => {
     if (isValid) {
@@ -89,8 +93,8 @@ const EcoCounterMarkers = ({ classes }) => {
 
   /**
    * Render markers on the map
-   * @param {boolean} isValid
-   * @param {array} data
+   * @param {boolean} isValid -true if data is valid, otherwise false
+   * @param {array} data -EcoCounter stations
    * @returns {JSX element}
    */
   const renderStations = (isValid, data) => (isValid ? (

--- a/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
+++ b/src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
@@ -45,9 +45,9 @@ const EcoCounterMarkers = ({ classes }) => {
   }, []);
 
   const stationsWithPedestrians = filterStations(ecoCounterStations);
-  /** All stations contain numbers about cyclist */
+  /** All stations contain data about cyclists */
   const renderAllStations = isDataValid(showEcoCounter.cycling, ecoCounterStations);
-  /** 4 stations contain numbrs about pedestrians as well */
+  /** 4 stations contain data about pedestrians as well */
   const renderFilteredStations = isDataValid(showEcoCounter.walking, stationsWithPedestrians);
 
   /**

--- a/src/layouts/DefaultLayout.js
+++ b/src/layouts/DefaultLayout.js
@@ -87,6 +87,11 @@ const createContentStyles = (
   return styles;
 };
 
+const ecoCounterStationsInitial = {
+  walking: false,
+  cycling: false,
+};
+
 // Shitty hack to get alert showing when not using print view
 // (showAlert did not use updated showPrintView value)
 const valueStore = {};
@@ -96,7 +101,7 @@ const DefaultLayout = (props) => {
   const [sidebarHidden, toggleSidebarHidden] = useState(false);
   const [error, setError] = useState(false);
   const [openMobilityPlatform, setOpenMobilityPlatform] = useState(false);
-  const [showEcoCounter, setShowEcoCounter] = useState(false);
+  const [showEcoCounter, setShowEcoCounter] = useState(ecoCounterStationsInitial);
   const [showBicycleStands, setShowBicycleStands] = useState(false);
   const [showCultureRoutes, setShowCultureRoutes] = useState(false);
   const [cultureRouteId, setCultureRouteId] = useState();

--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -263,7 +263,11 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
   }, [showPublicToilets]);
 
   useEffect(() => {
-    checkVisibilityValues(showEcoCounter, setOpenWalkSettings);
+    checkVisibilityValues(showEcoCounter.walking, setOpenWalkSettings);
+  }, [showEcoCounter]);
+
+  useEffect(() => {
+    checkVisibilityValues(showEcoCounter.cycling, setOpenBicycleSettings);
   }, [showEcoCounter]);
 
   useEffect(() => {
@@ -522,7 +526,15 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
    * @returns {boolean}
    */
   const ecoCounterStationsToggle = () => {
-    setShowEcoCounter(current => !current);
+    if (!showEcoCounter.walking) {
+      setShowEcoCounter(showEcoCounter => ({ ...showEcoCounter, walking: true }));
+    } else setShowEcoCounter(showEcoCounter => ({ ...showEcoCounter, walking: false }));
+  };
+
+  const ecoCounterStationsToggleCycling = () => {
+    if (!showEcoCounter.cycling) {
+      setShowEcoCounter(showEcoCounter => ({ ...showEcoCounter, cycling: true }));
+    } else setShowEcoCounter(showEcoCounter => ({ ...showEcoCounter, cycling: false }));
   };
 
   const bicycleStandsToggle = () => {
@@ -909,7 +921,7 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
     {
       type: 'ecoCounterStations',
       msgId: 'mobilityPlatform.menu.showEcoCounter',
-      checkedValue: showEcoCounter,
+      checkedValue: showEcoCounter.walking,
       onChangeValue: ecoCounterStationsToggle,
     },
     {
@@ -945,6 +957,12 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
   ];
 
   const bicycleControlTypes = [
+    {
+      type: 'ecoCounterStations',
+      msgId: 'mobilityPlatform.menu.showEcoCounter',
+      checkedValue: showEcoCounter.cycling,
+      onChangeValue: ecoCounterStationsToggleCycling,
+    },
     {
       type: 'bicycleRoutes',
       msgId: 'mobilityPlatform.menu.showBicycleRoutes',
@@ -1231,7 +1249,7 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
 
   const infoTextsWalking = [
     {
-      visible: showEcoCounter,
+      visible: showEcoCounter.walking,
       type: 'ecoCounterInfo',
       component: <InfoTextBox infoText="mobilityPlatform.info.ecoCounter" />,
     },
@@ -1253,6 +1271,11 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
   ];
 
   const infoTextsCycling = [
+    {
+      visible: showEcoCounter.cycling,
+      type: 'ecoCounterInfo',
+      component: <InfoTextBox infoText="mobilityPlatform.info.ecoCounter" />,
+    },
     {
       visible: showBicycleStands,
       type: 'bicycleStandsInfo',

--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -521,9 +521,9 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
   ]);
 
   /**
-   * Toggle functions for content types
-   * @var {boolean}
-   * @returns {boolean}
+   * Toggle function for EcoCounter stations that contain data about pedestrians
+   * @var {Object} showEcoCounter
+   * @returns {Object} showEcoCounter
    */
   const ecoCounterStationsToggle = () => {
     if (!showEcoCounter.walking) {
@@ -531,12 +531,22 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
     } else setShowEcoCounter(showEcoCounter => ({ ...showEcoCounter, walking: false }));
   };
 
+  /**
+   * Toggle function for EcoCounter stations that contain data about cyclists
+   * @var {Object} showEcoCounter
+   * @returns {Object} showEcoCounter
+   */
   const ecoCounterStationsToggleCycling = () => {
     if (!showEcoCounter.cycling) {
       setShowEcoCounter(showEcoCounter => ({ ...showEcoCounter, cycling: true }));
     } else setShowEcoCounter(showEcoCounter => ({ ...showEcoCounter, cycling: false }));
   };
 
+  /**
+   * Toggle functions for content types
+   * @var {boolean}
+   * @returns {boolean}
+   */
   const bicycleStandsToggle = () => {
     setShowBicycleStands(current => !current);
   };


### PR DESCRIPTION
# Update EcoCounter stations' division

## Only display all EcoCounter stations if user has selected them from cycling -section, because some stations only contain data about cyclists. If user has selected EcoCounter from walking -section, then show only stations, that contain data about pedestrians.

### Trello card 293

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Show all EcoCounter stations in cycling -section
 1. src/components/EcoCounter/EcoCounterMarkers/EcoCounterMarkers.js
     * If user has selected EcoCounter from cycling section, then display all measurement points. If user has selected EcoCounter from walking section, then show only stations, that contain data about pedestrians. Use function to filter data and move render function and fitBounds -function into separate functions.
   
 2. src/layouts/DefaultLayout.js
     * Replace basic boolean state with object containing 2 keys with boolean values.
    
 3. src/views/MobilitySettingsView/MobilitySettingsView.js
     * Update toggle functions and code that referenced old boolean value.