### PR TITLE
Update city bikes link

### DIFF
--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -743,7 +743,7 @@ const translations = {
   'mobilityPlatform.info.cityBikes.paragraph.1': 'Turun kaupunkipyörät eli tuttavallisemmin föllärit, ovat pyöriä, joita kuka vaan voi vuokrata Donkey Republicin sovelluksella.  Föllärin voi vuokrata kertamaksulla, kuukausimaksulla tai koko kesän kattavalla kausimaksulla.',
   'mobilityPlatform.info.cityBikes.paragraph.2': 'Jos sinulla on käytössä Fölin kausikortti, jonka kausi on vähintään 30 päivää, sisältää oikeuden käyttää fölläreitä tunnin ajan kerrallaan maksutta. Vuokrattavia pyöriä on 700 ja asemia yli 70 kappaletta.',
   'mobilityPlatform.info.cityBikes.subtitle': 'Lue lisää kaupunkipyöristä:',
-  'mobilityPlatform.info.cityBikes.link': 'https://foli.fi/föllärit',
+  'mobilityPlatform.info.cityBikes.link': 'https://www.foli.fi/fi/aikataulut-ja-reitit/fölifillarit',
   'mobilityPlatform.info.cityBikes.apiInfo': 'Kartan tiedot tulevat Donkey Republicin rajapinnasta reaaliajassa.',
   'mobilityPlatform.info.guestHarbour': 'Turun vierasvenesatama sijaitsee aivan keskustan kupeessa, osoitteessa Läntinen Rantakatu 57. Lisätietoja liittyen esimerkiksi venepaikan varaamiseen löytyy osoitteesta',
   'mobilityPlatform.info.guestHarbour.link': 'www.turunvierasvenesatama.fi',

--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -160,7 +160,7 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
     link: 'mobilityPlatform.info.cityBikes.link',
     apiInfo: 'mobilityPlatform.info.cityBikes.apiInfo',
     url: {
-      fi: 'https://foli.fi/föllärit',
+      fi: 'https://www.foli.fi/fi/aikataulut-ja-reitit/f%C3%B6lifillarit',
       en: 'https://www.foli.fi/en/f%C3%B6li-bikes',
       sv: 'https://www.foli.fi/sv/fölicyklar',
     },

--- a/src/views/MobilitySettingsView/components/CityBikeInfo/__tests__/__snapshots__/CityBikeInfo.test.js.snap
+++ b/src/views/MobilitySettingsView/components/CityBikeInfo/__tests__/__snapshots__/CityBikeInfo.test.js.snap
@@ -29,10 +29,10 @@ exports[`<CityBikeInfo /> should work 1`] = `
       target="_blank"
     >
       <p
-        aria-label="https://foli.fi/föllärit"
+        aria-label="https://www.foli.fi/fi/aikataulut-ja-reitit/fölifillarit"
         class="MuiTypography-root injectIntl(CityBikeInfo)-margin-2 MuiTypography-body2"
       >
-        https://foli.fi/föllärit
+        https://www.foli.fi/fi/aikataulut-ja-reitit/fölifillarit
       </p>
     </a>
     <p


### PR DESCRIPTION
# Update city bikes related link

## Previous link expired. Update Finnish link of city bikes into current link.

### Trello card 311

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Update link
 1. src/views/MobilitySettingsView/MobilitySettingsView.js
     * Update link value.
   
 2. src/i18n/fi.js
     * Update translation.
    
 3. src/views/MobilitySettingsView/components/CityBikeInfo/__tests__/__snapshots__/CityBikeInfo.test.js.snap
     * Update snapshot.
