### PR TITLE
Fix to ref error in home logo

### DIFF
--- a/src/components/Logos/HomeLogo/index.js
+++ b/src/components/Logos/HomeLogo/index.js
@@ -13,7 +13,7 @@ import logoNormal from '../../../assets/images/service-map-logo-fi.svg';
 import { useUserLocale } from '../../../utils/user';
 import styles from './styles';
 
-const HomeLogo = (props) => {
+const HomeLogo = React.forwardRef((props, ref) => {
   const {
     contrast, classes, ...rest
   } = props;
@@ -43,11 +43,11 @@ const HomeLogo = (props) => {
   const logo = getLogo(config.production, contrast);
 
   return (
-    <div role="img" {...rest}>
+    <div ref={ref} role="img" {...rest}>
       <img src={logo} alt="" className={classes.icon} />
     </div>
   );
-};
+});
 
 
 HomeLogo.propTypes = {

--- a/src/components/TopBar/SMLogo/__tests__/__snapshots__/SMLogo.test.js.snap
+++ b/src/components/TopBar/SMLogo/__tests__/__snapshots__/SMLogo.test.js.snap
@@ -16,7 +16,7 @@ exports[`<SMLogo /> should work 1`] = `
     >
       <img
         alt=""
-        class="HomeLogo-icon-26"
+        class="ForwardRef-icon-26"
         src="test-file-stub"
       />
     </div>


### PR DESCRIPTION
# Fix to ref error in HomeLogo

## Render method of the HomeLogo had inaccessible reference. For example navigating to the embedding tool caused an error message in the browser console. This fixes that by adding a correct ref value into the wrapper element of the logo.

### Trello card 384
-----------------------------------------------------------------------------------------------
### Breakdown:

#### Fix to ref error in HomeLogo
 1. src/components/Logos/HomeLogo/index.js
     * Add correct ref into the wrapper div of logo & use React.forwardRef.
  