### PR TITLE
Fix/unitview without location and geometry

### DIFF
--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -292,12 +292,14 @@ const MapView = (props) => {
     );
   };
 
+  const unitHasLocationAndGeometry = un => un?.location && un?.geometry;
+
   const renderUnitGeometry = () => {
     if (highlightedDistrict) return null;
     if (currentPage !== 'unit') {
       return unitData.map(unit => (unit.geometry ? <UnitGeometry key={unit.id} data={unit} /> : null));
     }
-    if (highlightedUnit) {
+    if (unitHasLocationAndGeometry(highlightedUnit)) {
       return <UnitGeometry data={highlightedUnit} />;
     }
     return null;
@@ -388,7 +390,8 @@ const MapView = (props) => {
 
           {currentPage === 'address' && <AddressMarker embedded={embedded} />}
 
-          {currentPage === 'unit' && highlightedUnit?.entrances?.length && <EntranceMarker />}
+          {currentPage === 'unit' && highlightedUnit?.entrances?.length && unitHasLocationAndGeometry(highlightedUnit) && (
+            <EntranceMarker />)}
 
           {!hideUserMarker && userLocation && (
             <UserMarker


### PR DESCRIPTION
# Fix to unit view

## Fix to unit view if unit does not have `location` or `geometry`.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Fix unitView when unit doesn't have location or geometry prop
 1. src/views/MapView/MapView.js
     * Check if unit does have `location` or `geometry`.
