### PR TITLE
Fix/maptype change error

### DIFF
--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -303,11 +303,17 @@ const MapView = (props) => {
     return null;
   };
 
+  const llMapHasMapPane = (leafLetMap) => {
+    // `getCenter()` call requires existence of mapPane (what ever that means). So check for that before calling it. Just another null check.
+    const panes = leafLetMap.getPanes();
+    return !!panes && !!panes.mapPane;
+  };
+
   if (global.rL && mapObject) {
     const { MapContainer, TileLayer, WMSTileLayer } = global.rL || {};
     let center = mapOptions.initialPosition;
     let zoom = isMobile ? mapObject.options.mobileZoom : mapObject.options.zoom;
-    if (prevMap) {
+    if (prevMap && llMapHasMapPane(prevMap)) {
       // If changing map type, use viewport values of previuous map
       center = prevMap.getCenter() || prevMap.props.center;
       /* Different map types have different zoom levels

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -315,13 +315,13 @@ const MapView = (props) => {
     let zoom = isMobile ? mapObject.options.mobileZoom : mapObject.options.zoom;
     if (prevMap && llMapHasMapPane(prevMap)) {
       // If changing map type, use viewport values of previuous map
-      center = prevMap.getCenter() || prevMap.props.center;
+      center = prevMap.getCenter() || prevMap.options.center;
       /* Different map types have different zoom levels
       Use the zoom difference to calculate the new zoom level */
       const zoomDifference = mapObject.options.zoom - prevMap.defaultZoom;
       zoom = prevMap.getZoom()
         ? prevMap.getZoom() + zoomDifference
-        : prevMap.props.zoom + zoomDifference;
+        : prevMap.options.zoom + zoomDifference;
     }
 
     const showLoadingScreen = districtViewFetching || (embedded && unitsLoading);


### PR DESCRIPTION
# Fix to an error on map type change

## Previously there was an error if `this._mapPane` was `undefined` on at least one instance of re-render after map type switch. Add function to check for `mapPane` existence before resolving "center".

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Check for mapPane existence before resolving center coordinates
 1. src/views/MapView/MapView.js
     * Add new function to check that `mapPane` exists before calling `center` function.
     
#### Use "options" instead of undefined "props"
 1. src/views/MapView/MapView.js
     * Use `options` instead of `props` because props  could be `undefined`.
   