### PR TITLE
Feature/area view tablist into accordion

### DIFF
--- a/src/components/SMAccordion/styles.js
+++ b/src/components/SMAccordion/styles.js
@@ -30,6 +30,7 @@ export default theme => ({
     height: '100%',
     justifyContent: 'left',
     textAlign: 'start',
+    wordBreak: 'break-word',
   },
   collapseContainer: {
     width: '100%',

--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Typography, List, ListItem } from '@material-ui/core';
-import { Map } from '@material-ui/icons';
+import { Map, BusinessCenter, LocationCity } from '@material-ui/icons';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
@@ -281,10 +281,12 @@ const AreaView = ({
       {
         component: renderServiceTab(),
         title: intl.formatMessage({ id: 'area.tab.publicServices' }),
+        icon: <BusinessCenter className={classes.icon} />,
       },
       {
         component: renderGeographicalTab(),
         title: intl.formatMessage({ id: 'area.tab.geographical' }),
+        icon: <LocationCity className={classes.icon} />,
       },
     ];
     if (!embed) {
@@ -318,13 +320,14 @@ const AreaView = ({
                   className={`${classes.listItem}`}
                 >
                   <SMAccordion // Top level categories
+                    adornment={category.icon}
                     defaultOpen={false}
                     disableUnmount
                     onOpen={(e, open) => areaSectionSelection(open, i)}
                     isOpen={areaSelection === i}
                     elevated={areaSelection === i}
                     titleContent={(
-                      <Typography component="h3" variant="subtitle1">
+                      <Typography component="p" variant="subtitle1">
                         {category.title}
                       </Typography>
                     )}

--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -1,18 +1,18 @@
-import { Typography } from '@material-ui/core';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Typography, List, ListItem } from '@material-ui/core';
 import { Map } from '@material-ui/icons';
 import PropTypes from 'prop-types';
-import React, { useCallback, useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import AddressSearchBar from '../../components/AddressSearchBar';
 import MobileComponent from '../../components/MobileComponent';
 import SMButton from '../../components/ServiceMapButton';
+import SMAccordion from '../../components/SMAccordion';
 import SettingsInfo from '../../components/SettingsInfo';
-import TabLists from '../../components/TabLists';
 import TitleBar from '../../components/TitleBar';
 import { handleOpenItems } from '../../redux/actions/district';
-import { formAddressString, parseSearchParams } from '../../utils';
+import { formAddressString, parseSearchParams, stringifySearchParams } from '../../utils';
 import { districtFetch } from '../../utils/fetch';
 import useLocaleText from '../../utils/useLocaleText';
 import fetchAddress from '../MapView/utils/fetchAddress';
@@ -59,6 +59,8 @@ const AreaView = ({
   // Get area parameter without year data
   const selectedAreaType = selectedArea?.split(/([\d]+)/)[0];
   const mapFocusDisabled = useMapFocusDisabled();
+  // Selected category handling
+  const [areaSelection, setAreaSelection] = useState(null);
 
   const getInitialOpenItems = () => {
     if (selectedAreaType) {
@@ -251,9 +253,31 @@ const AreaView = ({
     />
   );
 
+  const areaSectionSelection = (open, i) => {
+    setAreaSelection(!open ? i : null);
+    if (selectedDistrictType) {
+      clearRadioButtonValue();
+    }
+    // Since TabList component was changed in favor of Accordion this
+    // updates tab search param for keeping similar functionality as
+    // with TabList component
+    if (typeof i === 'number') {
+      searchParams.t = i;
+      // Get new search search params string
+      const searchString = stringifySearchParams(searchParams);
+      // Update select param to current history
+      if (navigator) {
+        navigator.replace({
+          ...location,
+          search: `?${searchString || ''}`,
+        });
+      }
+    }
+  };
+
 
   const render = () => {
-    const tabs = [
+    const categories = [
       {
         component: renderServiceTab(),
         title: intl.formatMessage({ id: 'area.tab.publicServices' }),
@@ -284,10 +308,31 @@ const AreaView = ({
               )}
             />
           </div>
-          <TabLists
-            onTabChange={() => (selectedDistrictType ? clearRadioButtonValue() : null)}
-            data={tabs}
-          />
+          <List>
+            {
+              categories.map((category, i) => (
+                <ListItem
+                  divider
+                  disableGutters
+                  key={category.title}
+                  className={`${classes.listItem}`}
+                >
+                  <SMAccordion // Top level categories
+                    defaultOpen={false}
+                    onOpen={(e, open) => areaSectionSelection(open, i)}
+                    isOpen={areaSelection === i}
+                    elevated={areaSelection === i}
+                    titleContent={(
+                      <Typography variant="subtitle1">
+                        {category.title}
+                      </Typography>
+                    )}
+                    collapseContent={category.component}
+                  />
+                </ListItem>
+              ))
+            }
+          </List>
           <SettingsInfo
             onlyCities
             title="settings.info.title.city"

--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -319,11 +319,12 @@ const AreaView = ({
                 >
                   <SMAccordion // Top level categories
                     defaultOpen={false}
+                    disableUnmount
                     onOpen={(e, open) => areaSectionSelection(open, i)}
                     isOpen={areaSelection === i}
                     elevated={areaSelection === i}
                     titleContent={(
-                      <Typography variant="subtitle1">
+                      <Typography component="h3" variant="subtitle1">
                         {category.title}
                       </Typography>
                     )}

--- a/src/views/AreaView/components/DistrictAreaList/DistrictAreaList.js
+++ b/src/views/AreaView/components/DistrictAreaList/DistrictAreaList.js
@@ -4,7 +4,6 @@ import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { DistrictItem } from '../../../../components';
-import SMAccordion from '../../../../components/SMAccordion';
 import { getAddressDistrict } from '../../../../redux/selectors/district';
 import { sortByOriginID } from '../../utils';
 
@@ -46,19 +45,14 @@ export const DistrictAreaList = ({
   }
 
   const renderServiceListAccordion = (title, districts) => (
-    <SMAccordion
-      className={classes.serviceListAccordion}
-      defaultOpen
-      titleContent={<Typography>{`${title} (${districts.length})`}</Typography>}
-      disabled={!districts.length}
-      collapseContent={(
-        <List className={classes.serviceListPadding} disablePadding>
-          {districts.map(district => (
-            <DistrictItem key={district.id} area={district} title={false} paddedDivider />
-          ))}
-        </List>
-      )}
-    />
+    <div className={classes.serviceTabServiceList}>
+      <Typography>{`${title} (${districts.length})`}</Typography>
+      <List disablePadding>
+        {districts.map(district => (
+          <DistrictItem key={district.id} area={district} title={false} paddedDivider />
+        ))}
+      </List>
+    </div>
   );
 
   sortByOriginID(filteredData);

--- a/src/views/AreaView/components/DistrictUnitList/DistrictUnitList.js
+++ b/src/views/AreaView/components/DistrictUnitList/DistrictUnitList.js
@@ -63,20 +63,13 @@ const DistrictUnitList = (props) => {
     );
   };
 
-  const renderServiceListAccordion = (title, districts) => (
-    <SMAccordion
-      className={classes.serviceListAccordion}
-      defaultOpen
-      titleContent={<Typography>{`${title} (${districts.length})`}</Typography>}
-      disabled={!districts.length}
-      collapseContent={(
-        <List className={`${classes.serviceListPadding} districtUnits`} disablePadding>
-          {districts.map(district => (
-            renderDistrictUnitItem(district)
-          ))}
-        </List>
-      )}
-    />
+  const renderServiceListAccordion = (title, unitList) => (
+    <div className={classes.serviceTabServiceList}>
+      <Typography>{`${title} (${unitList.length})`}</Typography>
+      <List className="districtUnits" disablePadding>
+        {unitList.map(unit => renderDistrictUnitItem(unit))}
+      </List>
+    </div>
   );
 
 

--- a/src/views/AreaView/components/GeographicalDistrictList/GeographicalDistrictList.js
+++ b/src/views/AreaView/components/GeographicalDistrictList/GeographicalDistrictList.js
@@ -75,7 +75,7 @@ const GeographicalDistrictList = ({ district, classes }) => {
   return (
     <>
       <div className={classes.municipalitySubtitle}>
-        <Typography component="h4" className={classes.bold}>
+        <Typography component="h5" className={classes.bold}>
           <FormattedMessage id={`area.${district.name}.title`} />
         </Typography>
       </div>
@@ -84,7 +84,7 @@ const GeographicalDistrictList = ({ district, classes }) => {
         return (
           <React.Fragment key={municipality}>
             <div className={classes.municipalitySubtitle}>
-              <Typography component="h5" className={classes.bold}>
+              <Typography component="h6" className={classes.bold}>
                 <FormattedMessage id={`settings.city.${municipality}`} />
               </Typography>
             </div>

--- a/src/views/AreaView/components/GeographicalDistrictList/GeographicalDistrictList.js
+++ b/src/views/AreaView/components/GeographicalDistrictList/GeographicalDistrictList.js
@@ -1,5 +1,5 @@
 import {
-    Checkbox, FormControlLabel, List, ListItem, Typography
+  Checkbox, FormControlLabel, List, ListItem, Typography,
 } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -75,7 +75,7 @@ const GeographicalDistrictList = ({ district, classes }) => {
   return (
     <>
       <div className={classes.municipalitySubtitle}>
-        <Typography component="h5" className={classes.bold}>
+        <Typography component="h4" className={classes.bold}>
           <FormattedMessage id={`area.${district.name}.title`} />
         </Typography>
       </div>
@@ -84,7 +84,7 @@ const GeographicalDistrictList = ({ district, classes }) => {
         return (
           <React.Fragment key={municipality}>
             <div className={classes.municipalitySubtitle}>
-              <Typography component="h6" className={classes.bold}>
+              <Typography component="h5" className={classes.bold}>
                 <FormattedMessage id={`settings.city.${municipality}`} />
               </Typography>
             </div>

--- a/src/views/AreaView/components/GeographicalTab/GeographicalTab.js
+++ b/src/views/AreaView/components/GeographicalTab/GeographicalTab.js
@@ -124,7 +124,7 @@ const GeographicalTab = ({
         {localAddressData?.address && localAddressData.districts?.length && (
           renderAddressInfo()
         )}
-        <Typography variant="srOnly" component="h4">
+        <Typography variant="srOnly" component="h3">
           <FormattedMessage id="area.list" />
         </Typography>
         <List className={`${classes.listNoPadding} ${classes.listLevelTwo}`}>

--- a/src/views/AreaView/components/GeographicalTab/GeographicalTab.js
+++ b/src/views/AreaView/components/GeographicalTab/GeographicalTab.js
@@ -127,19 +127,19 @@ const GeographicalTab = ({
         <Typography variant="srOnly" component="h4">
           <FormattedMessage id="area.list" />
         </Typography>
-        <List className={classes.listNoPadding}>
+        <List className={`${classes.listNoPadding} ${classes.listLevelTwo}`}>
           {districtItems.map((district) => {
             const opened = openCategory === district.id;
             const selected = selectedDistrictType === district.id;
             return (
               <ListItem
-                divider
                 disableGutters
                 key={district.id}
                 className={`${classes.listItem} ${district.id}`}
               >
                 <SMAccordion // Top level categories (neighborhood and postcode area)
                   defaultOpen={initialOpenItems.includes(district.id)}
+                  className={classes.geographicalCategoryListAccordion}
                   onOpen={(e, open) => handleAccordionToggle(district, !open)}
                   isOpen={opened}
                   elevated={opened}
@@ -157,7 +157,7 @@ const GeographicalTab = ({
                     </Typography>
                   )}
                   collapseContent={(
-                    <div className={classes.districtServiceList}>
+                    <div className={`${classes.districtServiceList} ${classes.listLevelThree}`}>
                       <SMAccordion // Unit list accordion
                         defaultOpen={initialOpenItems.some(item => typeof item === 'number')}
                         disabled={!filteredSubdistrictUnitsLength}

--- a/src/views/AreaView/components/GeographicalTab/GeographicalTab.js
+++ b/src/views/AreaView/components/GeographicalTab/GeographicalTab.js
@@ -10,7 +10,7 @@ import {
   handleOpenGeographicalCategory,
   setSelectedDistrictServices,
   setSelectedDistrictType,
-  setSelectedSubdistricts
+  setSelectedSubdistricts,
 } from '../../../../redux/actions/district';
 import { getFilteredSubdistrictServices } from '../../../../redux/selectors/district';
 import { formAddressString } from '../../../../utils';
@@ -124,7 +124,7 @@ const GeographicalTab = ({
         {localAddressData?.address && localAddressData.districts?.length && (
           renderAddressInfo()
         )}
-        <Typography variant="srOnly" component="h3">
+        <Typography variant="srOnly" component="h4">
           <FormattedMessage id="area.list" />
         </Typography>
         <List className={classes.listNoPadding}>

--- a/src/views/AreaView/components/GeographicalTab/GeographicalTab.js
+++ b/src/views/AreaView/components/GeographicalTab/GeographicalTab.js
@@ -127,7 +127,7 @@ const GeographicalTab = ({
         <Typography variant="srOnly" component="h3">
           <FormattedMessage id="area.list" />
         </Typography>
-        <List>
+        <List className={classes.listNoPadding}>
           {districtItems.map((district) => {
             const opened = openCategory === district.id;
             const selected = selectedDistrictType === district.id;

--- a/src/views/AreaView/components/ServiceTab/ServiceTab.js
+++ b/src/views/AreaView/components/ServiceTab/ServiceTab.js
@@ -139,7 +139,7 @@ const ServiceTab = (props) => {
 
   return (
     <div>
-      <Typography variant="srOnly" component="h3">
+      <Typography variant="srOnly" component="h4">
         <FormattedMessage id="area.list" />
       </Typography>
       <List>{districtCategoryList.map(item => renderCategoryItem(item))}</List>

--- a/src/views/AreaView/components/ServiceTab/ServiceTab.js
+++ b/src/views/AreaView/components/ServiceTab/ServiceTab.js
@@ -57,12 +57,11 @@ const ServiceTab = (props) => {
     const listDistrictAreas = ['rescue_area', 'rescue_district', 'rescue_sub_district'].includes(selectedDistrictType);
     const DistrictList = listDistrictAreas ? DistrictAreaList : DistrictUnitList;
     return (
-      <List className="districtList" disablePadding>
-        {districList.map((district, i) => (
+      <List className={`districtList ${classes.listLevelThree}`} disablePadding>
+        {districList.map(district => (
           <Fragment key={district.id}>
             <ListItem
               key={district.id}
-              divider={districList.length !== i + 1}
               className={`${classes.listItem} ${classes.areaItem} ${district.id}`}
             >
               {renderDistrictItem(district)}
@@ -86,7 +85,7 @@ const ServiceTab = (props) => {
         const districList = districtData.filter(i => obj.districts.includes(i.name));
         return (
           <React.Fragment key={obj.titleID}>
-            <div className={classes.subtitle}>
+            <div className={classes.serviceTabSubtitle}>
               <Typography>
                 <FormattedMessage id={obj.titleID} />
               </Typography>
@@ -106,7 +105,7 @@ const ServiceTab = (props) => {
     return (
       <ListItem key={item.titleID} className={classes.listItem} divider>
         <SMAccordion
-          className={classes.accodrion}
+          className={classes.accordion}
           onOpen={() => dispatch(handleOpenItems(item.id))}
           defaultOpen={defaultExpanded}
           titleContent={(
@@ -142,7 +141,9 @@ const ServiceTab = (props) => {
       <Typography variant="srOnly" component="h4">
         <FormattedMessage id="area.list" />
       </Typography>
-      <List>{districtCategoryList.map(item => renderCategoryItem(item))}</List>
+      <List className={`${classes.listLevelTwo} ${classes.serviceTabCategoryList}`}>
+        {districtCategoryList.map(item => renderCategoryItem(item))}
+      </List>
     </div>
   );
 };

--- a/src/views/AreaView/styles.js
+++ b/src/views/AreaView/styles.js
@@ -18,7 +18,15 @@ const styles = theme => ({
   list: {
     paddingLeft: 10,
   },
-  subsistrictAccordion: {
+  listNoPadding: {
+    padding: 0,
+    marginTop: theme.spacing(0),
+    marginBottom: theme.spacing(0),
+    '& li:last-of-type': {
+      borderBottom: 'none',
+    },
+  },
+  subdistrictAccordion: {
     padding: 0,
     marginLeft: -11,
   },

--- a/src/views/AreaView/styles.js
+++ b/src/views/AreaView/styles.js
@@ -1,4 +1,19 @@
 const styles = theme => ({
+  listLevelTwo: {
+    backgroundColor: 'rgb(250,250,250)',
+  },
+  listLevelThree: {
+    backgroundColor: 'rgb(245,245,245)',
+  },
+  listLevelFour: {
+    backgroundColor: 'rgb(240,240,240)',
+  },
+  listLevelFive: {
+    backgroundColor: 'rgb(235,235,235)',
+  },
+  listLevelSix: {
+    backgroundColor: 'rgb(230,230,230)',
+  },
   topBar: {
     height: 24,
     backgroundColor: theme.palette.primary.main,
@@ -45,6 +60,19 @@ const styles = theme => ({
     justifyContent: 'center',
     height: 56,
   },
+  serviceTabSubtitle: {
+    height: 48,
+    display: 'flex',
+    alignItems: 'center',
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+    paddingLeft: theme.spacing(9),
+  },
+  serviceTabCategoryList: {
+    '& > li:last-of-type': {
+      borderBottom: 'none',
+    },
+  },
   subtitle: {
     height: 48,
     display: 'flex',
@@ -54,9 +82,9 @@ const styles = theme => ({
     paddingLeft: 26,
   },
   municipalitySubtitle: {
-    height: 48,
     display: 'flex',
-    alignItems: 'center',
+    flexDirection: 'column',
+    alignItems: 'start',
     paddingTop: theme.spacing(2),
     paddingBottom: theme.spacing(1),
     paddingLeft: theme.spacing(4),
@@ -67,14 +95,17 @@ const styles = theme => ({
     minHeight: theme.spacing(7),
   },
   areaItem: {
-    paddingLeft: theme.spacing(2),
+    paddingLeft: theme.spacing(8),
     paddingRight: theme.spacing(2),
+  },
+  geographicalCategoryListAccordion: {
+    paddingLeft: theme.spacing(7),
   },
   geoItem: {
     paddingLeft: theme.spacing(2),
   },
   serviceTitle: {
-    paddingLeft: 63,
+    paddingLeft: theme.spacing(10),
   },
   categoryItemContent: {
     paddingLeft: 32,
@@ -131,7 +162,7 @@ const styles = theme => ({
   subdistrictList: {
     paddingLeft: theme.spacing(3),
   },
-  accodrion: {
+  accordion: {
     paddingLeft: theme.spacing(3),
   },
   expandingElementContent: {
@@ -159,12 +190,8 @@ const styles = theme => ({
     alignItems: 'center',
     padding: 0,
   },
-  accoridonContent: {
-    paddingLeft: 0,
-    paddingRight: 0,
-  },
   unitList: {
-    paddingLeft: theme.spacing(8),
+    paddingLeft: theme.spacing(10),
     paddingRight: theme.spacing(4),
     paddingBottom: theme.spacing(1),
   },
@@ -172,20 +199,20 @@ const styles = theme => ({
     backgroundColor: 'rgba(222, 222, 222, 0.12)',
   },
   districtServiceList: {
-    backgroundColor: 'rgb(245,245,245)',
     boxShadow: 'inset 0px 4px 4px rgba(0, 0, 0, 0.06)',
   },
-  geogrpahicalDiststrictlist: {
-    backgroundColor: 'rgb(245,245,245)',
-    paddingLeft: 30,
+  serviceTabServiceList: {
+    paddingLeft: theme.spacing(10),
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
   },
-  serviceListAccordion: {
-    paddingLeft: 77,
-    height: 48,
+  icon: {
+    padding: theme.spacing(2),
+    paddingLeft: theme.spacing(0),
   },
   iconPadding: {
     padding: theme.spacing(2.5),
-    paddingLeft: 60,
+    paddingLeft: theme.spacing(7),
   },
   areaSwitch: {
     paddingLeft: theme.spacing(2),
@@ -227,9 +254,6 @@ const styles = theme => ({
     paddingBottom: theme.spacing(2),
     paddingLeft: 77,
     backgroundColor: 'rgb(230,243,254)',
-  },
-  serviceListPadding: {
-    paddingLeft: 72,
   },
   serviceDivider: {
     marginLeft: -72,


### PR DESCRIPTION
# Change tab lists into accordion

## Change tab lists to use accordion components in area view. Also update styles to match Helsinki.

### Trello card 393

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Change tablist into accordion
 1. src/views/AreaView/AreaView.js
     * Replace tablist into accordion component. Add function for area section selection.
   
 2. src/views/AreaView/components/GeographicalTab/GeographicalTab.js
     * Use new style class
    
 3. src/views/AreaView/styles.js
     * Add style for list with no padding.
     
#### Update lists into multilevel lists
 1. src/views/AreaView/components/DistrictAreaList/DistrictAreaList.js
     * Replace accordion with list.
   
 2. src/views/AreaView/components/DistrictUnitList/DistrictUnitList.js
     * Replace accordion with list.
    
 3. src/views/AreaView/components/GeographicalDistrictList/GeographicalDistrictList.js
      * Update headings.

 4. src/views/AreaView/components/GeographicalTab/GeographicalTab.js
     * Use new list styles.
   
 5. src/views/AreaView/components/ServiceTab/ServiceTab.js
     * Use new list styles.