### PR TITLE
Update/mobility map title change

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -289,7 +289,6 @@ const translations = {
   'general.pageTitles.area': 'Area page',
   'general.tools': 'Tools',
   'general.pageTitles.mobilityPlatform': 'Mobility map',
-  'general.pageTitles.mobilityPlatform.title': 'Mobility map',
   // Readspeaker
   'general.readspeaker.buttonText': 'Listen',
   'general.readspeaker.title': 'Listen with ReadSpeaker webReader',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -613,7 +613,6 @@ const translations = {
   'mobilityPlatform.info.statement': 'The mobility data platform of the service map has been developed as part of European Union Horizon 2020 programme funded SCALE-UP project (grant agreement no. 955332).',
 
   // Menu
-  'mobilityPlatform.menu.title': 'Mobility map',
   'mobilityPlatform.menu.subtitle': 'Settings',
   'mobilityPlatform.menu.title.walk': 'Walking',
   'mobilityPlatform.menu.title.bicycle': 'Cycling',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -290,8 +290,7 @@ const translations = {
   'general.pageTitles.info': 'Tietoa palvelusta',
   'general.pageTitles.feedback': 'Palautesivu',
   'general.pageTitles.area': 'Aluesivu',
-  'general.pageTitles.mobilityPlatform': 'Liikkuminen',
-  'general.pageTitles.mobilityPlatform.title': 'Liikkuminen',
+  'general.pageTitles.mobilityPlatform': 'Liikenne ja liikkuminen',
   // Readspeaker
   'general.readspeaker.buttonText': 'Kuuntele',
   'general.readspeaker.title': 'Kuuntele ReadSpeaker webReaderilla',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -325,7 +325,7 @@ const translations = {
   'home.message': 'Terveisiä palvelukartan kehittäjiltä',
   'home.send.feedback': 'Anna palautetta',
   'home.old.link': 'Linkki vanhaan Palvelukarttaan',
-  'home.buttons.mobilityPlatformSettings': 'Liikkuminen',
+  'home.buttons.mobilityPlatformSettings': 'Liikenne ja liikkuminen',
 
   // Location
   'location.notFound': 'Sijaintia ei löytynyt',
@@ -619,7 +619,6 @@ const translations = {
   'mobilityPlatform.info.statement': 'Palvelukartan liikkumisnäkymää on kehitetty osana Euroopan unionin Horizon 2020 -ohjelman rahoittamaa SCALE-UP -hanketta (avustussopimus nro 955332).',
 
   // Menu
-  'mobilityPlatform.menu.title': 'Liikkuminen',
   'mobilityPlatform.menu.subtitle': 'Asetukset',
   'mobilityPlatform.menu.title.walk': 'Kävely',
   'mobilityPlatform.menu.title.bicycle': 'Pyöräily',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -616,7 +616,6 @@ const translations = {
   'mobilityPlatform.info.statement': 'Mobilitetsdataplattformen från servicekartan har utvecklats som en del av SCALE-UP-projekt, finansierat av Europeiska unionens Horizon 2020-program (bidragsavtal nr 955332).',
 
   // Menu
-  'mobilityPlatform.menu.title': 'Mobilitet',
   'mobilityPlatform.menu.subtitle': 'Anpassa',
   'mobilityPlatform.menu.title.walk': 'Promenad',
   'mobilityPlatform.menu.title.bicycle': 'Cykling',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -310,7 +310,6 @@ const translations = {
   'general.time.short': 'kl.',
   'general.tools': 'Verktyg',
   'general.pageTitles.mobilityPlatform': 'Mobilitet',
-  'general.pageTitles.mobilityPlatform.title': 'Mobilitet',
   // Readspeaker
   'general.readspeaker.buttonText': 'Lyssna', // TODO: verify
   'general.readspeaker.title': 'Lyssna med ReadSpeaker webReader', // TODO: verify

--- a/src/layouts/components/ViewRouter/ViewRouter.js
+++ b/src/layouts/components/ViewRouter/ViewRouter.js
@@ -166,7 +166,7 @@ const Area = () => (
 
 const MobilityPlatform = () => (
   <TitleWrapper messageId="general.pageTitles.mobilityPlatform">
-    <PageWrapper headMsgId="general.pageTitles.mobilityPlatform.title" page="mobilityPlatform">
+    <PageWrapper headMsgId="general.pageTitles.mobilityPlatform" page="mobilityPlatform">
       <MobilitySettingsView />
     </PageWrapper>
   </TitleWrapper>

--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -528,7 +528,7 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
   const publicTransportSettingsToggle = () => {
     setOpenPublicTransportSettings(current => !current);
     if (!openPublicTransportSettings) {
-      navigator.push('mobilityPlatform', 'publicTransport');
+      navigator.push('mobilityPlatform', 'transport');
       setPageTitle(intl.formatMessage({ id: 'mobilityPlatform.menu.title.public.transport' }));
     }
   };
@@ -566,6 +566,7 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
       && !openBoatingSettings
       && !openScooterSettings
       && !openStreetMaintenanceSettings
+      && !openPublicTransportSettings
       && pageTitle
     ) {
       setPageTitle(null);
@@ -577,6 +578,7 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
     openBoatingSettings,
     openScooterSettings,
     openStreetMaintenanceSettings,
+    openPublicTransportSettings,
     pageTitle,
   ]);
 

--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -1592,7 +1592,7 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
 
   /** Render header */
   const renderHead = () => {
-    const title = intl.formatMessage({ id: 'general.pageTitles.mobilityPlatform.title' });
+    const title = intl.formatMessage({ id: 'general.pageTitles.mobilityPlatform' });
     const appTitle = intl.formatMessage({ id: 'app.title' });
     return (
       <Helmet>
@@ -1786,7 +1786,7 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
     <div className={classes.content}>
       {renderHead()}
       <TitleBar
-        title={intl.formatMessage({ id: 'general.pageTitles.mobilityPlatform.title' })}
+        title={intl.formatMessage({ id: 'general.pageTitles.mobilityPlatform' })}
         titleComponent="h3"
         backButton
         backButtonOnClick={() => navigator.push('home')}


### PR DESCRIPTION
# Update Finnish title of the mobility map

## Update Finnish title of the mobility map and update URL value of the public transport section. Also fix page title that was incorrectly updated.

### Trello card 405

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Update texts
 1. src/i18n/en.js & src/i18n/fi.js & src/i18n/sv.js
     * Update Finnish text and remove unused values.
   
 2. src/layouts/components/ViewRouter/ViewRouter.js
     * Use updated value.
     
#### Update URL
 1. src/views/MobilitySettingsView/MobilitySettingsView.js
     * Update URL value of the public transport section and use new page title. Fix to bug that caused public transport page title value to be reset incorrectly.
