### PR TITLE
Feature/new mobility icon

### DIFF
--- a/src/components/SMIcon/index.js
+++ b/src/components/SMIcon/index.js
@@ -24,7 +24,6 @@ import closeIcon from '../../assets/icons/closeIcon.svg';
 import coordinateMarker from '../../assets/icons/CoordinateMarker.svg';
 import coordinateMarkerContrast from '../../assets/icons/CoordinateMarkerContrast.svg';
 import kirkkonummiIcon from '../../assets/icons/kirkkonummiIcon.svg';
-import iconMobilityPlatform from '../../assets/icons/inlineSVGs/iconMobilityPlatform';
 
 /**
  * Senses
@@ -123,8 +122,6 @@ export const getIcon = (key, props) => {
       return feedbackIcon();
     case 'help':
       return helpIcon();
-    case 'mobilityPlatformIcon':
-      return iconMobilityPlatform();
 
     // Social media links
     case 'facebook':

--- a/src/components/TopBar/DrawerMenu/DrawerMenu.js
+++ b/src/components/TopBar/DrawerMenu/DrawerMenu.js
@@ -1,7 +1,5 @@
-import {
-    Drawer
-} from '@material-ui/core';
-import { Map } from '@material-ui/icons';
+import { Drawer } from '@material-ui/core';
+import { Map, DirectionsBike } from '@material-ui/icons';
 import PropTypes from 'prop-types';
 import React from 'react';
 import useLocaleText from '../../../utils/useLocaleText';
@@ -46,7 +44,7 @@ const DrawerMenu = (props) => {
     { // Mobility platform button
       name: intl.formatMessage({ id: 'home.buttons.mobilityPlatformSettings' }),
       // active: currentPage === 'serviceTree' && !settingsOpen,
-      icon: getIcon('mobilityPlatformIcon'),
+      icon: <DirectionsBike />,
       clickEvent: () => {
         handleNavigation('mobilityPlatform');
         toggleDrawerMenu();

--- a/src/views/HomeView/HomeView.js
+++ b/src/views/HomeView/HomeView.js
@@ -1,4 +1,4 @@
-import { Map } from '@material-ui/icons';
+import { Map, DirectionsBike } from '@material-ui/icons';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useIntl } from 'react-intl';
@@ -50,7 +50,7 @@ const HomeView = (props) => {
             {/* Turku mobility platform settings */}
             <PaperButton
               messageID="home.buttons.mobilityPlatformSettings"
-              icon={getIcon('mobilityPlatformIcon')}
+              icon={<DirectionsBike />}
               link
               onClick={() => navigator.push('mobilityPlatform')}
             />


### PR DESCRIPTION
# Change mobility map icon

## Use Material-UI icon (DirectionsBike) in buttons that open mobility map.

### Trello card 365

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Use new icon for mobility map buttons
 1. src/views/HomeView/HomeView.js
     * Use DirectionsBike icon from MUI icons library & remove the old icon.
   
 2. src/components/TopBar/DrawerMenu/DrawerMenu.js
     * Use DirectionsBike icon from MUI icons library & remove the old icon.
    
 3. src/components/SMIcon/index.js
     * Remove the now unused icon from imports and the case in getIcon function.
     