### PR TITLE
Fix/trail list names

### DIFF
--- a/src/components/ListItems/ResultItem/ResultItem.js
+++ b/src/components/ListItems/ResultItem/ResultItem.js
@@ -3,8 +3,8 @@ import React, { useEffect } from 'react';
 import {
   Divider, ListItem, ListItemIcon, Typography,
 } from '@material-ui/core';
-import { useTheme } from '@material-ui/styles';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import { keyboardHandler } from '../../../utils';
 import locationIcon from '../../../assets/icons/LocationDefault.svg';
 import locationIconContrast from '../../../assets/icons/LocationDefaultContrast.svg';
@@ -30,7 +30,7 @@ const ResultItem = ({
   simpleItem,
   ...rest
 }) => {
-  const theme = useTheme();
+  const theme = useSelector(state => state.user.theme);
 
   const resetMarkerHighlight = () => {
     // Handle marker highlight removal

--- a/src/views/MobilitySettingsView/components/TrailList/TrailList.js
+++ b/src/views/MobilitySettingsView/components/TrailList/TrailList.js
@@ -24,7 +24,7 @@ const TrailList = ({
   };
 
   const renderName = (item) => {
-    if (item.content_types[0].name === 'PaavonPolku') {
+    if (item.content_types[0].type_name === 'PaavonPolku') {
       return fixRouteName(item.name_fi, item.name_en, item.name_sv);
     } return item.name;
   };


### PR DESCRIPTION
# Few bugfixes

## Fixed renderName function to look for correct key. Also fixed ResultItem using wrong highlight color for markers.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Fixed outdated check in renderName -function
 1. src/views/MobilitySettingsView/components/TrailList/TrailList.js
     * If statement in renderName -function looked for outdated key. Updated key name.
     
#### Fix ResultItem hover marker highlight using wrong color
 1. src/components/ListItems/ResultItem/ResultItem.js
     * Fix ResultItem theme using wrong hook and causing hover highlight replacing unit markers with normal contrast icons rather than high contrast
