### PR TITLE
Fix/heading skips

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,8 @@ MODE=development
 
 #ACCESSIBILITY_SENTENCE_API="https://www.hel.fi/palvelukarttaws/rest/v4"
 SERVICEMAP_API="https://palvelukartta-api.turku.fi/api/v2"
-#EVENTS_API="https://linkedevents-api.turku.fi/v1"
-#RESERVATIONS_API="https://api.hel.fi/respa/v1"
+EVENTS_API="https://linkedevents-api.turku.fi/v1"
+RESERVATIONS_API="https://respa.turku.fi/v1"
 FEEDBACK_URL="https://palvelukartta-api.turku.fi/open311/"
 DIGITRANSIT_API="https://api.digitransit.fi/routing/v2/routers/waltti/index/graphql"
 #HEARING_MAP_API="https://kuulokuvat.fi/api/v1/servicemap-url"

--- a/src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/BicycleStandContent.js
+++ b/src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/BicycleStandContent.js
@@ -18,7 +18,7 @@ const BicycleStandContent = ({
 
   const titleTypo = () => (
     <div className={classes.title}>
-      <Typography variant="subtitle1" className={classes.titleText}>
+      <Typography variant="subtitle1" component="h3" className={classes.titleText}>
         {bicycleStand.name}
       </Typography>
     </div>

--- a/src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/__tests__/BicycleStandContent.test.js
+++ b/src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/__tests__/BicycleStandContent.test.js
@@ -29,9 +29,9 @@ describe('<BicycleStandContent />', () => {
   it('does show text correctly', () => {
     const { container } = renderWithProviders(<BicycleStandContent {...mockProps} />);
 
-    const h6 = container.querySelector('h6');
+    const h3 = container.querySelector('h3');
     const p = container.querySelectorAll('p');
-    expect(h6.textContent).toContain(mockProps.bicycleStand.name);
+    expect(h3.textContent).toContain(mockProps.bicycleStand.name);
     expect(p[0].textContent).toContain('Malli: Testimalli');
     expect(p[1].textContent).toContain('Pyöräpaikkojen määrä: 10');
     expect(p[2].textContent).toContain('Pyörätelineiden määrä: 5');

--- a/src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/__tests__/__snapshots__/BicycleStandContent.test.js.snap
+++ b/src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/__tests__/__snapshots__/BicycleStandContent.test.js.snap
@@ -8,11 +8,11 @@ exports[`<BicycleStandContent /> should work 1`] = `
     <div
       class="injectIntl(BicycleStandContent)-title-1"
     >
-      <h6
+      <h3
         class="MuiTypography-root MuiTypography-subtitle1 injectIntl(BicycleStandContent)-titleText-2 css-dlbwt1-MuiTypography-root"
       >
         Testinimi
-      </h6>
+      </h3>
     </div>
     <div>
       <div

--- a/src/components/MobilityPlatform/Boating/Marinas/components/MarinasContent/MarinasContent.js
+++ b/src/components/MobilityPlatform/Boating/Marinas/components/MarinasContent/MarinasContent.js
@@ -64,7 +64,7 @@ const MarinasContent = ({
   return (
     <div className={classes.container}>
       <div className={classes.headerContainer}>
-        <Typography variant="subtitle1">
+        <Typography variant="subtitle1" component="h3">
           {berthItem.name}
         </Typography>
       </div>

--- a/src/components/MobilityPlatform/Boating/Marinas/components/MarinasContent/__tests__/MarinasContent.test.js
+++ b/src/components/MobilityPlatform/Boating/Marinas/components/MarinasContent/__tests__/MarinasContent.test.js
@@ -31,9 +31,9 @@ describe('<MarinasContent />', () => {
   it('does show text correctly', () => {
     const { container } = renderWithProviders(<MarinasContent {...mockProps} />);
 
-    const h6 = container.querySelectorAll('h6');
+    const h3 = container.querySelectorAll('h3');
     const p = container.querySelectorAll('p');
-    expect(h6[0].textContent).toContain(mockProps.berthItem.name);
+    expect(h3[0].textContent).toContain(mockProps.berthItem.name);
     expect(p[0].textContent).toContain('Venepaikkojen määrä: 1');
     expect(p[1].textContent).toContain(finnishTranslations['mobilityPlatform.content.marinas.typeTitle']);
     expect(p[2].textContent).toContain(

--- a/src/components/MobilityPlatform/Boating/Marinas/components/MarinasContent/__tests__/__snapshots__/MarinasContent.test.js.snap
+++ b/src/components/MobilityPlatform/Boating/Marinas/components/MarinasContent/__tests__/__snapshots__/MarinasContent.test.js.snap
@@ -8,11 +8,11 @@ exports[`<MarinasContent /> should work 1`] = `
     <div
       class="injectIntl(MarinasContent)-headerContainer-2"
     >
-      <h6
+      <h3
         class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
       >
         Satama: Marina
-      </h6>
+      </h3>
     </div>
     <div
       class="injectIntl(MarinasContent)-textContainer-3"

--- a/src/components/MobilityPlatform/ChargerStationMarkers/components/ChargerStationContent/ChargerStationContent.js
+++ b/src/components/MobilityPlatform/ChargerStationMarkers/components/ChargerStationContent/ChargerStationContent.js
@@ -6,7 +6,7 @@ import TextComponent from '../../../TextComponent';
 const ChargerStationContent = ({ classes, intl, station }) => {
   const titleTypo = (messageId, props = {}) => (
     <div {...props}>
-      <Typography variant="subtitle2">
+      <Typography variant="subtitle2" component="h3">
         {intl.formatMessage({
           id: messageId,
         })}

--- a/src/components/MobilityPlatform/ChargerStationMarkers/components/ChargerStationContent/__tests__/ChargerStationContent.test.js
+++ b/src/components/MobilityPlatform/ChargerStationMarkers/components/ChargerStationContent/__tests__/ChargerStationContent.test.js
@@ -46,10 +46,10 @@ describe('<ChargerStationContent />', () => {
   it('does show text correctly', () => {
     const { container } = renderWithProviders(<ChargerStationContent {...mockProps} />);
 
-    const h6 = container.querySelectorAll('h6');
+    const h3 = container.querySelectorAll('h3');
     const p = container.querySelectorAll('p');
     expect(p[0].textContent).toEqual(mockProps.station.name);
-    expect(h6[0].textContent).toEqual(`${finnishTranslations['mobilityPlatform.content.chargersTitle']}:`);
+    expect(h3[0].textContent).toEqual(`${finnishTranslations['mobilityPlatform.content.chargersTitle']}:`);
     expect(p[1].textContent).toEqual(`Osoite: ${mockProps.station.address_fi}`);
     expect(p[2].textContent).toEqual(`Ylläpitäjä: ${mockProps.station.extra.administrator.fi}`);
     expect(p[3].textContent).toEqual(`${finnishTranslations['mobilityPlatform.chargerStations.content.charge']}`);

--- a/src/components/MobilityPlatform/ChargerStationMarkers/components/ChargerStationContent/__tests__/__snapshots__/ChargerStationContent.test.js.snap
+++ b/src/components/MobilityPlatform/ChargerStationMarkers/components/ChargerStationContent/__tests__/__snapshots__/ChargerStationContent.test.js.snap
@@ -51,12 +51,12 @@ exports[`<ChargerStationContent /> should match snapshot 1`] = `
       <div
         class="injectIntl(ChargerStationContent)-margin-5"
       >
-        <h6
+        <h3
           class="MuiTypography-root MuiTypography-subtitle2 css-chrj9w-MuiTypography-root"
         >
           Latausasemat
           :
-        </h6>
+        </h3>
       </div>
       <div
         class="injectIntl(ChargerStationContent)-contentInner-4"

--- a/src/components/MobilityPlatform/CityBikes/components/CityBikesContent/CityBikesContent.js
+++ b/src/components/MobilityPlatform/CityBikes/components/CityBikesContent/CityBikesContent.js
@@ -52,7 +52,7 @@ const CityBikesContent = ({
   return (
     <div className={classes.popupInner}>
       <div className={classes.subtitle}>
-        <Typography variant="subtitle1">
+        <Typography variant="subtitle1" component="h3">
           {intl.formatMessage({ id: 'mobilityPlatform.content.cityBikes.title' })}
         </Typography>
       </div>

--- a/src/components/MobilityPlatform/CityBikes/components/CityBikesContent/__tests__/CityBikesContent.test.js
+++ b/src/components/MobilityPlatform/CityBikes/components/CityBikesContent/__tests__/CityBikesContent.test.js
@@ -41,9 +41,9 @@ describe('<CityBikesContent />', () => {
     const { container } = renderWithProviders(<CityBikesContent {...mockProps} />);
 
     const p = container.querySelectorAll('p');
-    const h6 = container.querySelector('h6');
+    const h3 = container.querySelector('h3');
     const link = container.querySelectorAll('a');
-    expect(h6.textContent).toContain(finnishTranslations['mobilityPlatform.content.cityBikes.title']);
+    expect(h3.textContent).toContain(finnishTranslations['mobilityPlatform.content.cityBikes.title']);
     expect(p[0].textContent).toContain(`${finnishTranslations['mobilityPlatform.content.cityBikes.name']}: ${mockProps.bikeStation.name}`);
     expect(p[1].textContent).toContain(finnishTranslations['mobilityPlatform.content.cityBikes.virtualStation']);
     expect(p[2].textContent).toContain(`${finnishTranslations['mobilityPlatform.content.cityBikes.capacity']}: ${mockProps.bikeStation.capacity}`);

--- a/src/components/MobilityPlatform/CityBikes/components/CityBikesContent/__tests__/__snapshots__/CityBikesContent.test.js.snap
+++ b/src/components/MobilityPlatform/CityBikes/components/CityBikesContent/__tests__/__snapshots__/CityBikesContent.test.js.snap
@@ -8,11 +8,11 @@ exports[`<CityBikesContent /> should work 1`] = `
     <div
       class="injectIntl(CityBikesContent)-subtitle-2"
     >
-      <h6
+      <h3
         class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
       >
         Kaupunkipyöräasema
-      </h6>
+      </h3>
     </div>
     <div
       class="injectIntl(CityBikesContent)-paragraph-3"

--- a/src/components/MobilityPlatform/CultureRoutes/components/CultureRouteUnits/CultureRouteUnits.js
+++ b/src/components/MobilityPlatform/CultureRoutes/components/CultureRouteUnits/CultureRouteUnits.js
@@ -100,7 +100,7 @@ const CultureRouteUnits = ({ classes, cultureRouteUnits }) => {
               <Popup closeButton={false} maxHeight={400} className="culture-route-unit-popup">
                 <div className={classes.popupInner}>
                   <div className={classes.header}>
-                    <Typography variant="subtitle1">
+                    <Typography variant="subtitle1" component="h3">
                       {getRouteUnitName(item.name, item.name_en, item.name_sv)}
                     </Typography>
                     <ButtonBase onClick={() => closePopup()} className={classes.popupCloseButton}>

--- a/src/components/MobilityPlatform/GasFillingStationMarkers/components/GasFillingStationContent/GasFillingStationContent.js
+++ b/src/components/MobilityPlatform/GasFillingStationMarkers/components/GasFillingStationContent/GasFillingStationContent.js
@@ -22,7 +22,7 @@ const GasFillingStationContent = ({ classes, intl, station }) => {
   return (
     <div className={classes.container}>
       <div className={classes.headerContainer}>
-        <Typography variant="subtitle1">
+        <Typography variant="subtitle1" component="h3">
           {station.name}
         </Typography>
       </div>

--- a/src/components/MobilityPlatform/GasFillingStationMarkers/components/GasFillingStationContent/__tests__/GasFillingStationContent.test.js
+++ b/src/components/MobilityPlatform/GasFillingStationMarkers/components/GasFillingStationContent/__tests__/GasFillingStationContent.test.js
@@ -26,8 +26,8 @@ describe('<GasFillingStationContent />', () => {
     const { container } = renderWithProviders(<GasFillingStationContent {...mockProps} />);
 
     const p = container.querySelectorAll('p');
-    const h6 = container.querySelector('h6');
-    expect(h6.textContent).toContain(mockProps.station.name);
+    const h3 = container.querySelector('h3');
+    expect(h3.textContent).toContain(mockProps.station.name);
     expect(p[0].textContent).toContain(`Osoite: ${mockProps.station.address}`);
     expect(p[1].textContent).toContain(`Kaasuaseman tyyppi: ${mockProps.station.extra.lng_cng}`);
     expect(p[2].textContent).toContain(`Operaattori: ${mockProps.station.extra.operator}`);

--- a/src/components/MobilityPlatform/GasFillingStationMarkers/components/GasFillingStationContent/__tests__/__snapshots__/GasFillingStationContent.test.js.snap
+++ b/src/components/MobilityPlatform/GasFillingStationMarkers/components/GasFillingStationContent/__tests__/__snapshots__/GasFillingStationContent.test.js.snap
@@ -8,11 +8,11 @@ exports[`<GasFillingStationContent /> should match snapshot 1`] = `
     <div
       class="injectIntl(GasFillingStationContent)-headerContainer-2"
     >
-      <h6
+      <h3
         class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
       >
         Testinimi
-      </h6>
+      </h3>
     </div>
     <div
       class="injectIntl(GasFillingStationContent)-textContainer-3"

--- a/src/components/MobilityPlatform/Parking/DisabledParking/components/DisabledParkingContent/DisabledParkingContent.js
+++ b/src/components/MobilityPlatform/Parking/DisabledParking/components/DisabledParkingContent/DisabledParkingContent.js
@@ -21,14 +21,13 @@ const DisabledParkingContent = ({ classes, intl, item }) => {
           {intl.formatMessage({ id: 'mobilityPlatform.content.publicParking.access.gate' })}
         </Typography>
       );
-    } return null;
+    }
+    return null;
   };
 
   const renderText = (msgId, value, props = {}) => (
     <div {...props}>
-      <Typography variant="body2">
-        {intl.formatMessage({ id: msgId }, { value })}
-      </Typography>
+      <Typography variant="body2">{intl.formatMessage({ id: msgId }, { value })}</Typography>
     </div>
   );
 
@@ -43,19 +42,19 @@ const DisabledParkingContent = ({ classes, intl, item }) => {
   return (
     <div className={classes.container}>
       <div className={classes.headerContainer}>
-        <Typography variant="subtitle1">{intl.formatMessage({ id: 'mobilityPlatform.content.disabledParking.title' })}</Typography>
+        <Typography variant="subtitle1" component="h3">
+          {intl.formatMessage({ id: 'mobilityPlatform.content.disabledParking.title' })}
+        </Typography>
       </div>
       <div className={classes.textContainer}>
         {renderAddress()}
-        {renderText('mobilityPlatform.content.disabledParking.amount', item.extra.invapaikkoja, { className: classes.margin })}
+        {renderText('mobilityPlatform.content.disabledParking.amount', item.extra.invapaikkoja, {
+          className: classes.margin,
+        })}
         <div className={classes.margin}>
-          <Typography variant="body2">
-            {getLocaleText(item.extra.rajoitustyyppi)}
-          </Typography>
+          <Typography variant="body2">{getLocaleText(item.extra.rajoitustyyppi)}</Typography>
         </div>
-        <div className={classes.margin}>
-          {renderAccessInfo(item.extra.saavutettavuus.fi)}
-        </div>
+        <div className={classes.margin}>{renderAccessInfo(item.extra.saavutettavuus.fi)}</div>
       </div>
     </div>
   );

--- a/src/components/MobilityPlatform/Parking/DisabledParking/components/DisabledParkingContent/__tests__/DisabledParkingContent.test.js
+++ b/src/components/MobilityPlatform/Parking/DisabledParking/components/DisabledParkingContent/__tests__/DisabledParkingContent.test.js
@@ -35,8 +35,8 @@ describe('<DisabledParkingContent />', () => {
     const { container } = renderWithProviders(<DisabledParkingContent {...mockProps} />);
 
     const p = container.querySelectorAll('p');
-    const h6 = container.querySelector('h6');
-    expect(h6.textContent).toContain(finnishTranslations['mobilityPlatform.content.disabledParking.title']);
+    const h3 = container.querySelector('h3');
+    expect(h3.textContent).toContain(finnishTranslations['mobilityPlatform.content.disabledParking.title']);
     expect(p[0].textContent).toContain(`Osoite: ${mockProps.item.address_fi}`);
     expect(p[1].textContent).toContain(`Parkkipaikkojen määrä: ${mockProps.item.extra.invapaikkoja}`);
     expect(p[2].textContent).toContain(mockProps.item.extra.rajoitustyyppi.fi);

--- a/src/components/MobilityPlatform/Parking/DisabledParking/components/DisabledParkingContent/__tests__/__snapshots__/DisabledParkingContent.test.js.snap
+++ b/src/components/MobilityPlatform/Parking/DisabledParking/components/DisabledParkingContent/__tests__/__snapshots__/DisabledParkingContent.test.js.snap
@@ -8,11 +8,11 @@ exports[`<DisabledParkingContent /> does match snapshot 1`] = `
     <div
       class="injectIntl(DisabledParkingContent)-headerContainer-2"
     >
-      <h6
+      <h3
         class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
       >
         Pysäköintialue liikkumisesteisille
-      </h6>
+      </h3>
     </div>
     <div
       class="injectIntl(DisabledParkingContent)-textContainer-3"

--- a/src/components/MobilityPlatform/ParkingChargeZones/components/ParkingChargeZoneContent/ParkingChargeZoneContent.js
+++ b/src/components/MobilityPlatform/ParkingChargeZones/components/ParkingChargeZoneContent/ParkingChargeZoneContent.js
@@ -5,7 +5,7 @@ import React from 'react';
 const ParkingChargeZoneContent = ({ classes, intl, parkingChargeZone }) => {
   const renderText = (msgId, objValue, isTitle) => (
     <div className={isTitle ? classes.subtitle : classes.text}>
-      <Typography variant={isTitle ? 'subtitle1' : 'body2'}>
+      <Typography variant={isTitle ? 'subtitle1' : 'body2'} component={isTitle ? 'h3' : 'p'}>
         {intl.formatMessage({
           id: msgId,
         })}

--- a/src/components/MobilityPlatform/ParkingChargeZones/components/ParkingChargeZoneContent/__tests__/ParkingChargeZoneContent.test.js
+++ b/src/components/MobilityPlatform/ParkingChargeZones/components/ParkingChargeZoneContent/__tests__/ParkingChargeZoneContent.test.js
@@ -29,8 +29,8 @@ describe('<ParkingChargeZoneContent />', () => {
     const { container } = renderWithProviders(<ParkingChargeZoneContent {...mockProps} />);
 
     const p = container.querySelectorAll('p');
-    const h6 = container.querySelector('h6');
-    expect(h6.textContent).toContain(
+    const h3 = container.querySelector('h3');
+    expect(h3.textContent).toContain(
       `${finnishTranslations['mobilityPlatform.content.parkingChargeZones.zone']}: ${mockProps.parkingChargeZone.extra.maksuvyohyke}`,
     );
     expect(p[0].textContent).toContain(

--- a/src/components/MobilityPlatform/ParkingChargeZones/components/ParkingChargeZoneContent/__tests__/__snapshots__/ParkingChargeZoneContent.test.js.snap
+++ b/src/components/MobilityPlatform/ParkingChargeZones/components/ParkingChargeZoneContent/__tests__/__snapshots__/ParkingChargeZoneContent.test.js.snap
@@ -8,14 +8,14 @@ exports[`<ParkingChargeZoneContent /> should work 1`] = `
     <div
       class="injectIntl(ParkingChargeZoneContent)-subtitle-2"
     >
-      <h6
+      <h3
         class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
       >
         Vyöhyke
         :
          
         1
-      </h6>
+      </h3>
     </div>
     <div>
       <p

--- a/src/components/MobilityPlatform/ParkingMachines/components/ParkingMachinesContent/ParkingMachinesContent.js
+++ b/src/components/MobilityPlatform/ParkingMachines/components/ParkingMachinesContent/ParkingMachinesContent.js
@@ -24,7 +24,7 @@ const ParkingMachinesContent = ({ classes, intl, item }) => {
   const parkingMachineInfo = (
     <div className={classes.container}>
       <div className={classes.headerContainer}>
-        <Typography variant="subtitle1">
+        <Typography variant="subtitle1" component="h3">
           {intl.formatMessage({ id: 'mobilityPlatform.content.parkingMachine.title' })}
         </Typography>
       </div>

--- a/src/components/MobilityPlatform/ParkingMachines/components/ParkingMachinesContent/__tests__/ParkingMachinesContent.test.js
+++ b/src/components/MobilityPlatform/ParkingMachines/components/ParkingMachinesContent/__tests__/ParkingMachinesContent.test.js
@@ -40,9 +40,9 @@ describe('<ParkingMachinesContent />', () => {
   it('does show text correctly', () => {
     const { container } = renderWithProviders(<ParkingMachinesContent {...mockProps} />);
 
-    const h6 = container.querySelectorAll('h6');
+    const h3 = container.querySelectorAll('h3');
     const p = container.querySelectorAll('p');
-    expect(h6[0].textContent).toContain(finnishTranslations['mobilityPlatform.content.parkingMachine.title']);
+    expect(h3[0].textContent).toContain(finnishTranslations['mobilityPlatform.content.parkingMachine.title']);
     expect(p[0].textContent).toContain(`Osoite: ${mockProps.item.address_fi}`);
     expect(p[1].textContent).toContain(`Sijainti: ${mockProps.item.extra.Sijainti.fi}`);
     expect(p[2].textContent).toContain('Maksu: 1,8 €/t');

--- a/src/components/MobilityPlatform/ParkingMachines/components/ParkingMachinesContent/__tests__/__snapshots__/ParkingMachinesContent.test.js.snap
+++ b/src/components/MobilityPlatform/ParkingMachines/components/ParkingMachinesContent/__tests__/__snapshots__/ParkingMachinesContent.test.js.snap
@@ -9,11 +9,11 @@ exports[`<ParkingMachinesContent /> should match snapshot 1`] = `
       <div
         class="injectIntl(ParkingMachinesContent)-headerContainer-2"
       >
-        <h6
+        <h3
           class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
         >
           Pysäköintiautomaatti
-        </h6>
+        </h3>
       </div>
       <div
         class="injectIntl(ParkingMachinesContent)-textContainer-3"

--- a/src/components/MobilityPlatform/ParkingSpaces/components/ParkingSpacesContent/ParkingSpacesContent.js
+++ b/src/components/MobilityPlatform/ParkingSpaces/components/ParkingSpacesContent/ParkingSpacesContent.js
@@ -3,10 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 const ParkingSpacesContent = ({
-  classes,
-  intl,
-  parkingSpace,
-  parkingStatistics,
+  classes, intl, parkingSpace, parkingStatistics,
 }) => {
   let freeParkingSpaces = 0;
 
@@ -15,13 +12,13 @@ const ParkingSpacesContent = ({
   const renderText = (isTitle, translationId, text) => (
     <div className={isTitle ? classes.title : classes.text}>
       {isTitle ? (
-        <Typography variant="subtitle1">
+        <Typography variant="subtitle1" component="h3">
           {intl.formatMessage({
             id: translationId,
           })}
         </Typography>
       ) : (
-        <Typography variant="body2">
+        <Typography variant="body2" component="p">
           {intl.formatMessage({
             id: translationId,
           })}
@@ -49,13 +46,16 @@ const ParkingSpacesContent = ({
   );
 
   const renderParkingCount = (capacity, parkingCount) => {
-    freeParkingSpaces = (capacity - parkingCount);
+    freeParkingSpaces = capacity - parkingCount;
 
     return (
       <div key={capacity} className={classes.text}>
         {freeParkingSpaces > 0 ? (
           <Typography variant="body2">
-            {intl.formatMessage({ id: 'mobilityPlatform.content.parkingSpaces.parkingCount' }, { value: freeParkingSpaces, capacity })}
+            {intl.formatMessage(
+              { id: 'mobilityPlatform.content.parkingSpaces.parkingCount' },
+              { value: freeParkingSpaces, capacity },
+            )}
           </Typography>
         ) : (
           <Typography variant="body2">

--- a/src/components/MobilityPlatform/ParkingSpaces/components/ParkingSpacesContent/__tests__/ParkingSpacesContent.test.js
+++ b/src/components/MobilityPlatform/ParkingSpaces/components/ParkingSpacesContent/__tests__/ParkingSpacesContent.test.js
@@ -30,9 +30,9 @@ describe('<ParkingSpacesContent />', () => {
   it('does show text correctly', () => {
     const { container } = renderWithProviders(<ParkingSpacesContent {...mockProps} />);
 
-    const h6 = container.querySelectorAll('h6');
+    const h3 = container.querySelectorAll('h3');
     const p = container.querySelectorAll('p');
-    expect(h6[0].textContent).toContain(finnishTranslations['mobilityPlatform.content.parkingSpaces.title']);
+    expect(h3[0].textContent).toContain(finnishTranslations['mobilityPlatform.content.parkingSpaces.title']);
     expect(p[0].textContent).toContain(
       `${finnishTranslations['mobilityPlatform.content.parkingSpaces.type']}: ${finnishTranslations['mobilityPlatform.content.parkingSpaces.paid']}`,
     );

--- a/src/components/MobilityPlatform/ParkingSpaces/components/ParkingSpacesContent/__tests__/__snapshots__/ParkingSpacesContent.test.js.snap
+++ b/src/components/MobilityPlatform/ParkingSpaces/components/ParkingSpacesContent/__tests__/__snapshots__/ParkingSpacesContent.test.js.snap
@@ -8,11 +8,11 @@ exports[`<ParkingSpacesContent /> should work 1`] = `
     <div
       class="injectIntl(ParkingSpacesContent)-title-2"
     >
-      <h6
+      <h3
         class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
       >
         Pysäköintialue
-      </h6>
+      </h3>
     </div>
     <div
       class="injectIntl(ParkingSpacesContent)-text-3"

--- a/src/components/MobilityPlatform/PublicToilets/components/PublicToiletsContent/PublicToiletsContent.js
+++ b/src/components/MobilityPlatform/PublicToilets/components/PublicToiletsContent/PublicToiletsContent.js
@@ -5,7 +5,7 @@ import React from 'react';
 const PublicToiletsContent = ({ classes, intl }) => {
   const titleTypo = (messageId, props = {}) => (
     <div {...props}>
-      <Typography variant="subtitle1">
+      <Typography variant="subtitle1" component="h3">
         {intl.formatMessage({
           id: messageId,
         })}
@@ -15,7 +15,7 @@ const PublicToiletsContent = ({ classes, intl }) => {
 
   const singleValTypo = (messageId, isSubtitle, props = {}) => (
     <div {...props}>
-      <Typography variant={isSubtitle ? 'subtitle2' : 'body2'}>
+      <Typography variant={isSubtitle ? 'subtitle2' : 'body2'} component={isSubtitle ? 'h4' : 'p'}>
         {intl.formatMessage({
           id: messageId,
         })}
@@ -25,14 +25,14 @@ const PublicToiletsContent = ({ classes, intl }) => {
 
   return (
     <div className={classes.container}>
-      <div className={classes.headerContainer}>
-        {titleTypo('mobilityPlatform.content.publicToilets.title')}
-      </div>
+      <div className={classes.headerContainer}>{titleTypo('mobilityPlatform.content.publicToilets.title')}</div>
       <div className={classes.textContainer}>
         {singleValTypo('mobilityPlatform.content.publicToilets.openNormalTitle', true)}
         {singleValTypo('mobilityPlatform.content.publicToilets.openNormalDate')}
         {singleValTypo('mobilityPlatform.content.publicToilets.openNormal')}
-        {singleValTypo('mobilityPlatform.content.publicToilets.openSummerTitle', true, { className: classes.marginTop })}
+        {singleValTypo('mobilityPlatform.content.publicToilets.openSummerTitle', true, {
+          className: classes.marginTop,
+        })}
         {singleValTypo('mobilityPlatform.content.publicToilets.openSummerDate')}
         {singleValTypo('mobilityPlatform.content.publicToilets.openSummer')}
       </div>

--- a/src/components/MobilityPlatform/PublicToilets/components/PublicToiletsContent/__tests__/PublicToiletsContent.test.js
+++ b/src/components/MobilityPlatform/PublicToilets/components/PublicToiletsContent/__tests__/PublicToiletsContent.test.js
@@ -16,12 +16,13 @@ describe('<PublicToiletsContent />', () => {
     const { container } = renderWithProviders(<PublicToiletsContent />);
 
     const p = container.querySelectorAll('p');
-    const h6 = container.querySelectorAll('h6');
-    expect(h6[0].textContent).toContain(finnishTranslations['mobilityPlatform.content.publicToilets.title']);
-    expect(h6[1].textContent).toContain(finnishTranslations['mobilityPlatform.content.publicToilets.openNormalTitle']);
+    const h3 = container.querySelector('h3');
+    const h4 = container.querySelectorAll('h4');
+    expect(h3.textContent).toContain(finnishTranslations['mobilityPlatform.content.publicToilets.title']);
+    expect(h4[0].textContent).toContain(finnishTranslations['mobilityPlatform.content.publicToilets.openNormalTitle']);
     expect(p[0].textContent).toContain(finnishTranslations['mobilityPlatform.content.publicToilets.openNormalDate']);
     expect(p[1].textContent).toContain(finnishTranslations['mobilityPlatform.content.publicToilets.openNormal']);
-    expect(h6[2].textContent).toContain(finnishTranslations['mobilityPlatform.content.publicToilets.openSummerTitle']);
+    expect(h4[1].textContent).toContain(finnishTranslations['mobilityPlatform.content.publicToilets.openSummerTitle']);
     expect(p[2].textContent).toContain(finnishTranslations['mobilityPlatform.content.publicToilets.openSummerDate']);
     expect(p[3].textContent).toContain(finnishTranslations['mobilityPlatform.content.publicToilets.openSummer']);
   });

--- a/src/components/MobilityPlatform/PublicToilets/components/PublicToiletsContent/__tests__/__snapshots__/PublicToiletsContent.test.js.snap
+++ b/src/components/MobilityPlatform/PublicToilets/components/PublicToiletsContent/__tests__/__snapshots__/PublicToiletsContent.test.js.snap
@@ -9,22 +9,22 @@ exports[`<PublicToiletsContent /> should work 1`] = `
       class="injectIntl(PublicToiletsContent)-headerContainer-2"
     >
       <div>
-        <h6
+        <h3
           class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
         >
           Yleinen vessa
-        </h6>
+        </h3>
       </div>
     </div>
     <div
       class="injectIntl(PublicToiletsContent)-textContainer-3"
     >
       <div>
-        <h6
+        <h4
           class="MuiTypography-root MuiTypography-subtitle2 css-chrj9w-MuiTypography-root"
         >
           Aukioloajat:
-        </h6>
+        </h4>
       </div>
       <div>
         <p
@@ -43,11 +43,11 @@ exports[`<PublicToiletsContent /> should work 1`] = `
       <div
         class="injectIntl(PublicToiletsContent)-marginTop-5"
       >
-        <h6
+        <h4
           class="MuiTypography-root MuiTypography-subtitle2 css-chrj9w-MuiTypography-root"
         >
           Erityisaukioloajat:
-        </h6>
+        </h4>
       </div>
       <div>
         <p

--- a/src/components/MobilityPlatform/RentalCars/components/RentalCarsContent/RentalCarsContent.js
+++ b/src/components/MobilityPlatform/RentalCars/components/RentalCarsContent/RentalCarsContent.js
@@ -8,7 +8,7 @@ const RentalCarsContent = ({ classes, intl, car }) => {
 
   const titleText = (messageId, props = {}) => (
     <div className={classes.title}>
-      <Typography variant="subtitle1" {...props}>
+      <Typography variant="subtitle1" component="h3" {...props}>
         {intl.formatMessage({
           id: messageId,
         })}
@@ -53,12 +53,11 @@ const RentalCarsContent = ({ classes, intl, car }) => {
       {titleText('mobilityPlatform.content.rentalCars.title')}
       {contentText('mobilityPlatform.content.general.provider', serviceProvider)}
       <div className={classes.linkContainer}>
-        <Link target="_blank" href={getLink(car.homeLocationData.fullAddress)}>
+        <Link role="link" target="_blank" href={getLink(car.homeLocationData.fullAddress)}>
           <Typography className={classes.link} variant="body2">
             {intl.formatMessage({
               id: 'mobilityPlatform.content.rentalCars.link',
             })}
-
           </Typography>
         </Link>
       </div>

--- a/src/components/MobilityPlatform/RentalCars/components/RentalCarsContent/__tests__/__snapshots__/RentalCarsContent.test.js.snap
+++ b/src/components/MobilityPlatform/RentalCars/components/RentalCarsContent/__tests__/__snapshots__/RentalCarsContent.test.js.snap
@@ -8,11 +8,11 @@ exports[`<RentalCarsContent /> should work 1`] = `
     <div
       class="injectIntl(RentalCarsContent)-title-2"
     >
-      <h6
+      <h3
         class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
       >
         Yhteiskäyttöauto
-      </h6>
+      </h3>
     </div>
     <div
       class="injectIntl(RentalCarsContent)-text-3"
@@ -29,6 +29,7 @@ exports[`<RentalCarsContent /> should work 1`] = `
       <a
         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-fixjtq-MuiTypography-root-MuiLink-root"
         href="https://www.24rent.fi/#/?city=Testiosoite"
+        role="link"
         target="_blank"
       >
         <p

--- a/src/components/MobilityPlatform/Scooters/components/ScooterMarkers/components/ScooterInfo/ScooterInfo.js
+++ b/src/components/MobilityPlatform/Scooters/components/ScooterMarkers/components/ScooterInfo/ScooterInfo.js
@@ -5,7 +5,7 @@ import React from 'react';
 const ScooterInfo = ({ classes, intl, item }) => {
   const titleTypo = messageId => (
     <div>
-      <Typography variant="subtitle1">
+      <Typography variant="subtitle1" component="h3">
         {intl.formatMessage({
           id: messageId,
         })}
@@ -35,7 +35,7 @@ const ScooterInfo = ({ classes, intl, item }) => {
 
   const renderLink = (linkUrl, text) => (
     <div className={classes.paragraph}>
-      <Link target="_blank" href={linkUrl}>
+      <Link role="link" target="_blank" href={linkUrl}>
         <Typography className={classes.link} variant="body2">
           {text}
         </Typography>

--- a/src/components/MobilityPlatform/Scooters/components/ScooterMarkers/components/ScooterInfo/__tests__/ScooterInfo.test.js
+++ b/src/components/MobilityPlatform/Scooters/components/ScooterMarkers/components/ScooterInfo/__tests__/ScooterInfo.test.js
@@ -28,8 +28,8 @@ describe('<ScooterInfo />', () => {
     const { container } = renderWithProviders(<ScooterInfo {...mockProps} />);
 
     const p = container.querySelectorAll('p');
-    const h6 = container.querySelector('h6');
-    expect(h6.textContent).toContain(finnishTranslations['mobilityPlatform.content.scooter.title']);
+    const h3 = container.querySelector('h3');
+    expect(h3.textContent).toContain(finnishTranslations['mobilityPlatform.content.scooter.title']);
     expect(p[0].textContent).toContain('Palveluntarjoaja: Ryde');
     expect(p[1].textContent).toContain(finnishTranslations['mobilityPlatform.content.scooter.notReserved']);
     expect(p[2].textContent).toContain('Jäljellä oleva kantama: 20.20 km');

--- a/src/components/MobilityPlatform/Scooters/components/ScooterMarkers/components/ScooterInfo/__tests__/__snapshots__/ScooterInfo.test.js.snap
+++ b/src/components/MobilityPlatform/Scooters/components/ScooterMarkers/components/ScooterInfo/__tests__/__snapshots__/ScooterInfo.test.js.snap
@@ -9,11 +9,11 @@ exports[`<ScooterInfo /> should work 1`] = `
       class="injectIntl(ScooterInfo)-headerContainer-2"
     >
       <div>
-        <h6
+        <h3
           class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
         >
           Sähköpotkulauta
-        </h6>
+        </h3>
       </div>
     </div>
     <div
@@ -62,6 +62,7 @@ exports[`<ScooterInfo /> should work 1`] = `
         <a
           class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-fixjtq-MuiTypography-root-MuiLink-root"
           href="https://www.testilinkki.fi"
+          role="link"
           target="_blank"
         >
           <p
@@ -77,6 +78,7 @@ exports[`<ScooterInfo /> should work 1`] = `
         <a
           class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-fixjtq-MuiTypography-root-MuiLink-root"
           href="https://www.testilinkki.fi"
+          role="link"
           target="_blank"
         >
           <p

--- a/src/components/MobilityPlatform/SnowPlows/components/SnowPlowsContent/SnowPlowsContent.js
+++ b/src/components/MobilityPlatform/SnowPlows/components/SnowPlowsContent/SnowPlowsContent.js
@@ -7,7 +7,7 @@ const SnowPlowsContent = ({
 }) => (
   <div className={classes.popupInner}>
     <div className={classes.subtitle}>
-      <Typography variant="subtitle1">
+      <Typography variant="subtitle1" component="h3">
         {intl.formatMessage({
           id: 'mobilityPlatform.content.streetMaintenance.title',
         })}

--- a/src/components/MobilityPlatform/SpeedLimitZones/components/SpeedLimitZonesContent/SpeedLimitZonesContent.js
+++ b/src/components/MobilityPlatform/SpeedLimitZones/components/SpeedLimitZonesContent/SpeedLimitZonesContent.js
@@ -5,7 +5,7 @@ import { Typography } from '@mui/material';
 const SpeedLimitZonesContent = ({ classes, intl, item }) => (
   <div className={classes.padding}>
     <div className={classes.subtitle}>
-      <Typography variant="subtitle1">
+      <Typography variant="subtitle1" component="h3">
         {intl.formatMessage({
           id: 'mobilityPlatform.content.speedLimitZones.area',
         })}

--- a/src/components/MobilityPlatform/SpeedLimitZones/components/SpeedLimitZonesContent/__tests__/SpeedLimitZonesContent.test.js
+++ b/src/components/MobilityPlatform/SpeedLimitZones/components/SpeedLimitZonesContent/__tests__/SpeedLimitZonesContent.test.js
@@ -24,8 +24,8 @@ describe('<SpeedLimitZonesContent />', () => {
     const { container } = renderWithProviders(<SpeedLimitZonesContent {...mockProps} />);
 
     const p = container.querySelectorAll('p');
-    const h6 = container.querySelector('h6');
-    expect(h6.textContent).toContain(finnishTranslations['mobilityPlatform.content.speedLimitZones.area']);
+    const h3 = container.querySelector('h3');
+    expect(h3.textContent).toContain(finnishTranslations['mobilityPlatform.content.speedLimitZones.area']);
     expect(p[0].textContent).toContain('Nopeusrajoitus: 40 km/t');
   });
 });

--- a/src/components/MobilityPlatform/SpeedLimitZones/components/SpeedLimitZonesContent/__tests__/__snapshots__/SpeedLimitZonesContent.test.js.snap
+++ b/src/components/MobilityPlatform/SpeedLimitZones/components/SpeedLimitZonesContent/__tests__/__snapshots__/SpeedLimitZonesContent.test.js.snap
@@ -8,11 +8,11 @@ exports[`<SpeedLimitZonesContent /> should match snapshot 1`] = `
     <div
       class="injectIntl(SpeedLimitZonesContent)-subtitle-2"
     >
-      <h6
+      <h3
         class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
       >
         Nopeusrajoitusalue
-      </h6>
+      </h3>
     </div>
     <p
       class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"

--- a/src/components/MobilityPlatform/TextContent/TextContent.js
+++ b/src/components/MobilityPlatform/TextContent/TextContent.js
@@ -7,7 +7,7 @@ const TextContent = ({
 }) => {
   const singleValTypo = (messageId, isTitle) => (
     <div>
-      <Typography variant={isTitle ? 'subtitle1' : 'body2'}>
+      <Typography variant={isTitle ? 'subtitle1' : 'body2'} component={isTitle ? 'h3' : 'p'}>
         {intl.formatMessage({
           id: messageId,
         })}

--- a/src/components/MobilityPlatform/TextContent/__tests__/TextContent.test.js
+++ b/src/components/MobilityPlatform/TextContent/__tests__/TextContent.test.js
@@ -21,8 +21,8 @@ describe('<TextContent />', () => {
     const { container } = renderWithProviders(<TextContent {...mockProps} />);
 
     const p = container.querySelectorAll('p');
-    const h6 = container.querySelector('h6');
-    expect(h6.textContent).toContain(finnishTranslations['mobilityPlatform.content.scooters.noParkingAreas.title']);
+    const h3 = container.querySelector('h3');
+    expect(h3.textContent).toContain(finnishTranslations['mobilityPlatform.content.scooters.noParkingAreas.title']);
     expect(p[0].textContent).toContain(finnishTranslations['mobilityPlatform.info.scooters.noParking']);
   });
 });

--- a/src/components/MobilityPlatform/TextContent/__tests__/__snapshots__/TextContent.test.js.snap
+++ b/src/components/MobilityPlatform/TextContent/__tests__/__snapshots__/TextContent.test.js.snap
@@ -9,11 +9,11 @@ exports[`<TextContent /> should work 1`] = `
       class="injectIntl(TextContent)-headerContainer-2"
     >
       <div>
-        <h6
+        <h3
           class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
         >
           Pysäköintikieltoalue
-        </h6>
+        </h3>
       </div>
     </div>
     <div

--- a/src/utils/fetch/constants.js
+++ b/src/utils/fetch/constants.js
@@ -30,7 +30,7 @@ export const APIHandlers = {
     options: {
       page_size: 5,
     },
-    envName: config.serviceMapAPI.id,
+    envName: config.reservationsAPI.id,
   },
   service: {
     url: id => `${config.serviceMapAPI.root}/service/${id}/`,


### PR DESCRIPTION
# Fix heading skips

## Fix to heading skips that occurred in some Leaflet modals that contained info texts.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Update heading component values
 1. src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/BicycleStandContent.js
     * Add component value h3 for title text to avoid heading skips.
   
 2. src/components/MobilityPlatform/Boating/Marinas/components/MarinasContent/MarinasContent.js
     * Add component value h3 for title text to avoid heading skips.
    
 3. ...rest
     * Add component value h3 for title text to avoid heading skips.
     
#### Update tests
 1. src/components/MobilityPlatform/BicycleStands/components/BicycleStandContent/__tests__/BicycleStandContent.test.js
     * Update tests to query for correct component.
   
 2. src/components/MobilityPlatform/Boating/Marinas/components/MarinasContent/__tests__/MarinasContent.test.js
     * Update tests to query for correct component.
    
 3. ...rest
      * Update tests to query for correct component.

#### Fix to envName constant in reservations object
 1. src/utils/fetch/constants.js
     * Returned wrong env value id if RESERVATIONS_API env value was missing.