### PR TITLE
Remove municipality param from search suggestions

### DIFF
--- a/src/components/SearchBar/createSuggestions.js
+++ b/src/components/SearchBar/createSuggestions.js
@@ -18,12 +18,11 @@ const createSuggestions = (
 
   const additionalOptions = {
     page_size: pageSize,
-    limit: 2000,
+    limit: 2500,
     unit_limit: unitLimit,
     service_limit: serviceLimit,
     address_limit: addressLimit,
     servicenode_limit: servicenodeLimit,
-    municipality: citySettings.join(','),
     language: locale,
   };
 


### PR DESCRIPTION
# Remove parameter from search suggestions

## Remove municipality parameter from search suggestions. If no city selection was made, search suggestions would be empty.

### Trello card 456

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Update parameters of search suggestions
 1. src/components/SearchBar/createSuggestions.js
     * Remove municipality parameter (it is not required) and increase limit. Previously empty parameter (municipality=) would return 0 suggestions. Now search endpoint will return suggestions even when city/municipality hasn't been selected.
   