### PR TITLE
Fix/filter counters without data

### DIFF
--- a/src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
+++ b/src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
@@ -39,7 +39,16 @@ const EcoCounterContent = ({
   const stationId = station.id;
   const stationName = station.name;
   const stationSource = station.csv_data_source;
-  const userTypes = station.sensor_types;
+
+  /** When all 3 user types are rendered, a reverse order is required where 'at' is placed last */
+  const reverseUserTypes = () => {
+    if (station.sensor_types.includes('at')) {
+      return [...station.sensor_types].reverse();
+    }
+    return station.sensor_types;
+  };
+
+  const userTypes = reverseUserTypes();
 
   const setUserTypeValue = () => {
     if (userTypes.includes('at')) {

--- a/src/components/EcoCounter/LamCounters/LamCounters.js
+++ b/src/components/EcoCounter/LamCounters/LamCounters.js
@@ -22,7 +22,18 @@ const LamCounters = () => {
     }
   }, [showLamCounter]);
 
-  const allStationsData = [].concat(lamCounterStations, trafficCounterStations);
+  /** Filter out stations that have empty sensor_types array.
+   * Those stations do not have data and sensor type(s) were never assigned.
+   * It only occurs in some counters operated by Turku.
+   * This will also prevent rendering bugs. */
+  const filteredTrafficCounters = trafficCounterStations.reduce((acc, curr) => {
+    if (curr.sensor_types.length) {
+      acc.push(curr);
+    }
+    return acc;
+  }, []);
+
+  const allStationsData = [].concat(lamCounterStations, filteredTrafficCounters);
 
   const map = useMap();
 

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -822,7 +822,7 @@ const translations = {
   'mobilityPlatform.info.scooters.speedLimitAreas': 'Maximum speed allowed on the areas shown on the map is 15 km/h.',
   'mobilityPlatform.info.scooters.general': 'The service map shows available electric scooters provided by operators. Electric scooters provided by other operators will be visible on the mobility view later.',
   'mobilityPlatform.info.disabledParking': 'Parking spaces intended for people with reduced mobility are shown on the map. To park on them, you need a disabled parking permit. There is accessible access to the parking places, excluding those parking places that can only be accessed through a gate.',
-  'mobilityPlatform.info.loadingPlaces': 'The map shows the places for loading and unloading goods.',
+  'mobilityPlatform.info.loadingPlaces': 'The map shows the places for loading and unloading goods. The information is based on a mappig carried out 08/2022.',
   'mobilityPlatform.info.streetMaintenance.noActivity': 'There is no street maintenance work in progress during the selected time period.',
   'mobilityPlatform.info.streetMaintenance.general': 'Street maintenance includes ploughing and sanding of streets, cycle paths and structurally indistinguishable footpaths and cycle paths in winter and removing the sand in spring.',
   'mobilityPlatform.info.streetMaintenance.link': 'Winter maintenance rules.',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -818,7 +818,7 @@ const translations = {
   'mobilityPlatform.info.scooters.speedLimitAreas': 'Ylin sallittu nopeus alueilla on 15 km/t.',
   'mobilityPlatform.info.scooters.general': 'Palvelukartalla näkyvät operaattorien vapaana olevat sähköpotkulaudat. Liikkumisnäkymään tullaan lisäämään tietoja muidenkin operaattorien sähköpotkulaudoista.',
   'mobilityPlatform.info.disabledParking': 'Kartalla näkyvät liikkumisesteisille tarkoitetut pysäköintipaikat. Niihin pysäköintiä varten tarvitsee liikkumisesteisen pysäköintitunnuksen. Paikkoihin on esteetön pääsy, poislukien ne pysäköintipaikat, joihin pääsee portin kautta.',
-  'mobilityPlatform.info.loadingPlaces': 'Kartalla näkyvät tavaroiden lastaukseen ja purkamiseen tarkoitetut paikat.',
+  'mobilityPlatform.info.loadingPlaces': 'Kartalla näkyvät tavaroiden lastaukseen ja purkamiseen tarkoitetut paikat. Tiedot perustuvat 08/2022 tehtyyn kartoitukseen.',
   'mobilityPlatform.info.streetMaintenance.noActivity': 'Kunnossapitotöitä ei ole meneillään valitulla ajanjaksolla.',
   'mobilityPlatform.info.streetMaintenance.general': 'Katujen kunnossapitoon kuuluu ajoratojen, pyöräteiden ja rakenteellisesti toisistaan erottamattomien jalankulku- ja pyöräteiden auraus sekä hiekoitus talvella ja hiekoitushiekan poisto keväällä.',
   'mobilityPlatform.info.streetMaintenance.link': 'Talvikunnossapidon pelisäännöt.',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -825,7 +825,7 @@ const translations = {
   'mobilityPlatform.info.scooters.speedLimitAreas': 'Hastigheten på området är max. 15km/h.',
   'mobilityPlatform.info.scooters.general': 'Servicekartan visar företagets lediga hyreselsparkcyklar. Andra leverantörers elsparkcyklar kommer att läggas till mobilitetsvyn senare.',
   'mobilityPlatform.info.disabledParking': 'Parkeringsplatser avsedda för personer med nedsatt rörlighet visas på kartan. För att parkera på dem behöver du ett parkeringstillstånd för rörelsehindrade. Plattserna ärr tillgängliga, förutom de som nås via en port.',
-  'mobilityPlatform.info.loadingPlaces': 'Kartan visar platserna som är avsedda för lastning och lossning av gods.',
+  'mobilityPlatform.info.loadingPlaces': 'Kartan visar platserna som är avsedda för lastning och lossning av gods. Informationen baserar sig på en kartläggning som gjordes 08/2022.',
   'mobilityPlatform.info.streetMaintenance.noActivity': 'Det pågår inget underhållsarbete under den valda tidsperioden.',
   'mobilityPlatform.info.streetMaintenance.general': 'Gatuunderhållet omfattar plogning och sandning av körbanor, cykelvägar och strukturellt oskiljaktiga gång- och cykelvägar på vintern och borttagning av sandingssand på våren.',
   'mobilityPlatform.info.streetMaintenance.link': 'Spelregler för vinterunderhåll.',


### PR DESCRIPTION
# Filter counters without data

## Filter counters without data (empty `sensor_types`). Also use reverse order when rendering user types on some traffic counters. Add new text as well.

### Trello 472 and 474

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Filter stations without sensor types
 1. src/components/EcoCounter/LamCounters/LamCounters.js
     * Check if `sensor_types` array is empty or not and filter counters that do not have `sensor types`. Such counters don't contain any `traffic data`.
     
#### Use reverse order
 1. src/components/EcoCounter/EcoCounterContent/EcoCounterContent.js
     * If all 3 `sensor types` exist, then use reverse order, because `at` is required to be last, not first.
   
#### Update texts
 1. src/i18n/en.js & src/i18n/fi.js & src/i18n/sv.js
     * Add new sentence.
