### PR TITLE
Fix/get min date from data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ SERVICEMAP_API_VERSION="/v2"
 RESERVATIONS_API="https://respa.turku.fi/v1"
 FEEDBACK_URL="https://palvelukartta-api.turku.fi/open311/"
 DIGITRANSIT_API="https://api.digitransit.fi/routing/v2/routers/waltti/index/graphql"
+# This is key for DIGITRANSIT API. There are separate urls and keys for prod (api.digitransit.fi) and dev (dev-api.digitransit.fi) digitransit apis.
+#DIGITRANSIT_API_KEY=
 #HEARING_MAP_API="https://kuulokuvat.fi/api/v1/servicemap-url"
 SERVICE_MAP_URL="https://maptiles.turku.fi/styles/hel-osm-bright/{z}/{x}/{y}"
 ACCESSIBLE_MAP_URL="https://maptiles.turku.fi/styles/high-contrast-map-layer/{z}/{x}/{y}"

--- a/config/default.js
+++ b/config/default.js
@@ -255,11 +255,6 @@ export default {
   "oldMapEn": settings.OLD_MAP_LINK_EN,
   "oldMapFi": settings.OLD_MAP_LINK_FI,
   "oldMapSv": settings.OLD_MAP_LINK_SV,
-  "accessibilityStatementURL": {
-    fi: settings.ACCESSIBILITY_STATEMENT_URL_FI,
-    sv: settings.ACCESSIBILITY_STATEMENT_URL_SV,
-    en: settings.ACCESSIBILITY_STATEMENT_URL_EN,
-  },
   "readspeakerLocales": {
     "fi": 'fi_fi',
     "en": 'en_uk',

--- a/src/components/EcoCounter/TrafficCounters/EcoCounterContent/EcoCounterContent.js
+++ b/src/components/EcoCounter/TrafficCounters/EcoCounterContent/EcoCounterContent.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable react-hooks/exhaustive-deps */
-/* eslint-disable no-nested-ternary */
 import { ButtonBase, Typography, useMediaQuery } from '@mui/material';
 import PropTypes from 'prop-types';
 import React, {

--- a/src/components/EcoCounter/TrafficCounters/LamCounterContent/LamCounterContent.js
+++ b/src/components/EcoCounter/TrafficCounters/LamCounterContent/LamCounterContent.js
@@ -62,6 +62,7 @@ const LamCounterContent = ({ classes, intl, station }) => {
   const stationName = station.name;
   const stationSource = station.csv_data_source;
   const userTypes = station.sensor_types;
+  const dataFromYear = station.data_from_year;
 
   // steps that determine which data is shown on the chart
   const buttonSteps = [
@@ -393,7 +394,7 @@ const LamCounterContent = ({ classes, intl, station }) => {
             dateFormat="P"
             showYearDropdown
             dropdownMode="select"
-            minDate={new Date('2015-01-01')}
+            minDate={new Date(`${dataFromYear}-01-01`)}
             maxDate={new Date()}
             customInput={<CustomInput inputRef={inputRef} />}
           />
@@ -463,6 +464,7 @@ LamCounterContent.propTypes = {
     name: PropTypes.string,
     csv_data_source: PropTypes.string,
     sensor_types: PropTypes.arrayOf(PropTypes.string),
+    data_from_year: PropTypes.number,
   }),
 };
 
@@ -472,6 +474,7 @@ LamCounterContent.defaultProps = {
     name: '',
     csv_data_source: '',
     sensor_types: [],
+    data_from_year: 2010,
   },
 };
 

--- a/src/components/EcoCounter/TrafficCounters/LamCounterContent/LamCounterContent.js
+++ b/src/components/EcoCounter/TrafficCounters/LamCounterContent/LamCounterContent.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable react-hooks/exhaustive-deps */
-/* eslint-disable no-nested-ternary */
 import React, {
   useEffect, useState, forwardRef, useRef,
 } from 'react';

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -750,7 +750,7 @@ const translations = {
   'mobilityPlatform.menu.parkingChargeZones.subtitle': 'Zone {value}',
   'mobilityPlatform.menu.showBikeServiceStations': 'Bicycle service stations',
   'mobilityPlatform.menu.showCityBikes': 'City bike stations',
-  'mobilityPlatform.menu.show.cargoBikes': 'Cargo bikes',
+  'mobilityPlatform.menu.show.cargoBikes': 'Cargo bike stations',
   'mobilityPlatform.menu.show.marinas': 'Marina berths',
   'mobilityPlatform.menu.show.boatParking': 'Boat parking',
   'mobilityPlatform.menu.show.guestHarbour': 'Guest harbour',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -755,7 +755,7 @@ const translations = {
   'mobilityPlatform.menu.parkingChargeZones.subtitle': 'Vyöhyke {value}',
   'mobilityPlatform.menu.showBikeServiceStations': 'Pyöränkorjauspisteet',
   'mobilityPlatform.menu.showCityBikes': 'Kaupunkipyöräasemat',
-  'mobilityPlatform.menu.show.cargoBikes': 'Tavarapyörät',
+  'mobilityPlatform.menu.show.cargoBikes': 'Tavarapyöräasemat',
   'mobilityPlatform.menu.show.marinas': 'Venesatamat',
   'mobilityPlatform.menu.show.boatParking': 'Veneparkit',
   'mobilityPlatform.menu.show.guestHarbour': 'Vierasvenesatama',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -754,7 +754,7 @@ const translations = {
   'mobilityPlatform.menu.parkingChargeZones.subtitle': 'Zon {value}',
   'mobilityPlatform.menu.showBikeServiceStations': 'Cykelservicestationer',
   'mobilityPlatform.menu.showCityBikes': 'Stadscykelstationer',
-  'mobilityPlatform.menu.show.cargoBikes': 'Lastcyklarna',
+  'mobilityPlatform.menu.show.cargoBikes': 'Lastcykelstationer',
   'mobilityPlatform.menu.show.marinas': 'Båtplatser',
   'mobilityPlatform.menu.show.boatParking': 'Båtparkering',
   'mobilityPlatform.menu.show.guestHarbour': 'Gästhamn',


### PR DESCRIPTION
# Get min date value from data.

## Get min date value from data for the datepicker component. Update texts and env example -file.

### Trello cards 93 & 495 & 496.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Get min date value from data
 1. src/components/EcoCounter/TrafficCounters/LamCounterContent/LamCounterContent.js
     * Assign the data from year value into variable and add it into the date picker's minDate prop.
       
#### Duplicate key
 1. config/default.js
     * Remove duplicate key.
   
#### Update texts
 1. src/i18n/en.js & src/i18n/fi.js & src/i18n/sv.js
     * Update texts.

#### Update env.example
 1. .env.example
     * Add value for Digitransit API key.