### PR TITLE
Fix/change min zoom value

### DIFF
--- a/src/views/MapView/config/mapConfig.js
+++ b/src/views/MapView/config/mapConfig.js
@@ -75,7 +75,7 @@ const mapTypes = {
     name: 'accessible_map',
     attribution: 'map.attribution.osm',
     generateUrl: (suffix = '') => `${config.accessibleMapURL}${suffix}.png`,
-    minZoom: 9,
+    minZoom: isExternalTheme ? 10 : 9,
     maxZoom: 18,
     zoom: 13,
     clusterPopupVisibility: 13,

--- a/src/views/MapView/config/mapConfig.js
+++ b/src/views/MapView/config/mapConfig.js
@@ -2,6 +2,11 @@
 import config from '../../../../config';
 import { isRetina } from '../../../utils';
 
+// Turku has less maptiles (which creates empty space on the right) at minZoom so that value could be less than Helsinki.
+// Using this it keeps both values.
+const externalTheme = config.themePKG;
+const isExternalTheme = !externalTheme || externalTheme === 'undefined' ? null : externalTheme;
+
 // The default maximum bounds of the map
 const defaultMapBounds = {
   maxLat: 61.755,
@@ -58,7 +63,7 @@ const mapTypes = {
     name: 'servicemap',
     attribution: 'map.attribution.osm',
     generateUrl: (suffix = '') => `${config.servicemapURL}${suffix}.png`,
-    minZoom: 9,
+    minZoom: isExternalTheme ? 10 : 9,
     maxZoom: 18,
     zoom: 13,
     clusterPopupVisibility: 13,

--- a/src/views/MapView/config/mapConfig.js
+++ b/src/views/MapView/config/mapConfig.js
@@ -2,8 +2,8 @@
 import config from '../../../../config';
 import { isRetina } from '../../../utils';
 
-// Turku has less maptiles (which creates empty space on the right) at minZoom so that value could be less than Helsinki.
-// Using this it keeps both values.
+// Turku has less maptiles (which creates empty space on the right) if minZoom is 9.
+// Keeps original minZoom value but uses new value.
 const externalTheme = config.themePKG;
 const isExternalTheme = !externalTheme || externalTheme === 'undefined' ? null : externalTheme;
 


### PR DESCRIPTION
# Change minZoom value

## Update minZoom value to decrease empty space on the right & decrease number of cases where it might show. This is because Turku has less maptiles.

### Trello cards 174 & 219

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Change minZoom value
 1. src/views/MapView/config/mapConfig.js
     * Change minZoom value from 9 to 10 for default map background and for high contrast background.
   