### PR TITLE
Use updated date values in datepicker

### DIFF
--- a/src/components/EcoCounter/TrafficCounters/LamCounterContent/LamCounterContent.js
+++ b/src/components/EcoCounter/TrafficCounters/LamCounterContent/LamCounterContent.js
@@ -61,7 +61,8 @@ const LamCounterContent = ({ classes, intl, station }) => {
   const stationName = station.name;
   const stationSource = station.csv_data_source;
   const userTypes = station.sensor_types;
-  const dataFromYear = station.data_from_year;
+  const dataFrom = station.data_from_date;
+  const dataUntil = station.data_until_date;
 
   // steps that determine which data is shown on the chart
   const buttonSteps = [
@@ -393,8 +394,8 @@ const LamCounterContent = ({ classes, intl, station }) => {
             dateFormat="P"
             showYearDropdown
             dropdownMode="select"
-            minDate={new Date(`${dataFromYear}-01-01`)}
-            maxDate={new Date()}
+            minDate={new Date(dataFrom)}
+            maxDate={new Date(dataUntil)}
             customInput={<CustomInput inputRef={inputRef} />}
           />
         </div>
@@ -463,7 +464,8 @@ LamCounterContent.propTypes = {
     name: PropTypes.string,
     csv_data_source: PropTypes.string,
     sensor_types: PropTypes.arrayOf(PropTypes.string),
-    data_from_year: PropTypes.number,
+    data_from_date: PropTypes.string,
+    data_until_date: PropTypes.string,
   }),
 };
 
@@ -473,7 +475,8 @@ LamCounterContent.defaultProps = {
     name: '',
     csv_data_source: '',
     sensor_types: [],
-    data_from_year: 2010,
+    data_from_date: '2010-02-01',
+    data_until_date: '2020-30-01',
   },
 };
 


### PR DESCRIPTION
# Use updated values in date-picker

## Replace old and now removed object value with updated values in the date-picker in traffic counters.

### Trello card 525

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Use new values in date-picker
 1. src/components/EcoCounter/TrafficCounters/LamCounterContent/LamCounterContent.js
     * Use `data_from_date` and `data_until_date` values in date-picker element to keep year selection and date limits working. Old `data_from_year` value has been removed from data.
  
