### PR TITLE
Fix/traffic counters loading performance

### DIFF
--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -6,6 +6,7 @@
         "no-console": ["error", { "allow": ["warn"] }],
         "no-param-reassign": ["error", { "props": false }],
         "max-len": ["error", { "code": 150 }],
+        "arrow-parens": ["warn", "as-needed"],
         "react/function-component-definition": [
             "error",
             {

--- a/src/components/EcoCounter/TrafficCounters/TrafficCounters.js
+++ b/src/components/EcoCounter/TrafficCounters/TrafficCounters.js
@@ -18,19 +18,19 @@ const TrafficCounters = () => {
   const { showTrafficCounter } = useMobilityPlatformContext();
 
   useEffect(() => {
-    if (showTrafficCounter.walking) {
+    if (showTrafficCounter.walking && !pedestrianCounterStations.length) {
       fetchTrafficCounterStationsByType('j', setPedestrianCounterStations);
     }
   }, [showTrafficCounter.walking]);
 
   useEffect(() => {
-    if (showTrafficCounter.cycling) {
+    if (showTrafficCounter.cycling && !bicycleCounterStations.length) {
       fetchTrafficCounterStationsByType('p', setBicycleCounterStations);
     }
   }, [showTrafficCounter.cycling]);
 
   useEffect(() => {
-    if (showTrafficCounter.driving) {
+    if (showTrafficCounter.driving && !carCounterStations.length) {
       fetchTrafficCounterStationsByType('a', setCarCounterStations);
     }
   }, [showTrafficCounter.driving]);

--- a/src/components/EcoCounter/TrafficCounters/TrafficCounters.js
+++ b/src/components/EcoCounter/TrafficCounters/TrafficCounters.js
@@ -44,7 +44,7 @@ const TrafficCounters = () => {
   const fitToMapBounds = (isValid, data) => {
     if (isValid) {
       const bounds = [];
-      data.forEach((item) => {
+      data.forEach(item => {
         bounds.push([item.lat, item.lon]);
       });
       map.fitBounds(bounds);
@@ -63,7 +63,7 @@ const TrafficCounters = () => {
     fitToMapBounds(renderCarCounters, carCounterStations);
   }, [renderCarCounters, carCounterStations]);
 
-  const renderContent = (item) => {
+  const renderContent = item => {
     const csvSource = item.csv_data_source;
     if (csvSource === 'EC' || csvSource === 'TR') {
       return <EcoCounterContent station={item} />;
@@ -76,7 +76,7 @@ const TrafficCounters = () => {
 
   const renderStationsOnMap = (renderData, data) => (
     renderData ? (
-      data.map((item) => (
+      data.map(item => (
         <CounterMarkers key={item.id} counterStation={item}>
           {renderContent(item)}
         </CounterMarkers>


### PR DESCRIPTION
# Update fetch of traffic counters

## Update condition when to fetch the data of traffic counters.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Update fetch
 1. src/components/EcoCounter/TrafficCounters/TrafficCounters.js
     * Some queries in back-end cause slowness when fetching data of (several) traffic counters. Limits number of fetches & will now fetch data only when in initial state. This will improve usability after the initial fetch.
        
#### Update eslint
 1. src/.eslintrc
     * Add new rule.
   