### PR TITLE
Open element if roadworks have been selected

### DIFF
--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -473,6 +473,10 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
     checkVisibilityValues(showAirMonitoringStations, setOpenAirMonitoringSettings);
   }, [showAirMonitoringStations]);
 
+  useEffect(() => {
+    checkVisibilityValues(showRoadworks, setOpenRoadworkSettings);
+  }, [showRoadworks]);
+
   const nameKeys = {
     fi: 'name',
     en: 'name_en',


### PR DESCRIPTION
# Update accordion element

## Check if roadworks have been selected and not hidden and then open the accordion if user returns to the view.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Kategoria-otsikko
 1. src/views/MobilitySettingsView/MobilitySettingsView.js
     * Check if roadworks have been selected previously and not turned off and then open the accordion element if user returns to the view.
   
