### PR TITLE
Feature/counters render period text

### DIFF
--- a/src/components/EcoCounter/TrafficCounters/CounterActiveText/CounterActiveText.js
+++ b/src/components/EcoCounter/TrafficCounters/CounterActiveText/CounterActiveText.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+import { Typography } from '@mui/material';
+import styled from '@emotion/styled';
+import { formatFullDates } from '../../utils';
+
+/**
+ * Render text that shows from and until dates.
+ * @prop {string} dataFrom
+ * @prop {string} dataUntil
+ * @returns JSX eement
+ */
+const CounterActiveText = ({ dataFrom, dataUntil }) => {
+  const intl = useIntl();
+  const dataFromFormat = formatFullDates(dataFrom);
+  const dataUntilFormat = formatFullDates(dataUntil);
+
+  return (
+    <StyledTextContainer>
+      <Typography variant="body2" sx={{ mb: '0.4rem' }}>
+        {intl.formatMessage(
+          { id: 'ecocounter.station.counts.period' },
+          { value1: dataFromFormat, value2: dataUntilFormat },
+        )}
+      </Typography>
+    </StyledTextContainer>
+  );
+};
+
+const StyledTextContainer = styled.div(({ theme }) => ({
+  textAlign: 'center',
+  margin: `${theme.spacing(1)} 0`,
+}));
+
+CounterActiveText.propTypes = {
+  dataFrom: PropTypes.string,
+  dataUntil: PropTypes.string,
+};
+
+CounterActiveText.defaultProps = {
+  dataFrom: '',
+  dataUntil: '',
+};
+
+export default CounterActiveText;

--- a/src/components/EcoCounter/TrafficCounters/CounterActiveText/__tests__/CounterActiveText.test.js
+++ b/src/components/EcoCounter/TrafficCounters/CounterActiveText/__tests__/CounterActiveText.test.js
@@ -1,0 +1,26 @@
+/* eslint-disable react/jsx-props-no-spreading */
+// Link.react.test.js
+import React from 'react';
+import CounterActiveText from '../index';
+import { getRenderWithProviders } from '../../../../../../jestUtils';
+
+const mockProps = {
+  dataFrom: '2020-01-01',
+  dataUntil: '2023-10-10',
+};
+
+const renderWithProviders = getRenderWithProviders({});
+
+describe('<CounterActiveText />', () => {
+  it('should work', () => {
+    const { container } = renderWithProviders(<CounterActiveText {...mockProps} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('does show text correctly', () => {
+    const { container } = renderWithProviders(<CounterActiveText {...mockProps} />);
+
+    const p = container.querySelectorAll('p');
+    expect(p[0].textContent).toEqual('Laskentatiedot ovat väliltä 01.01.2020 - 10.10.2023');
+  });
+});

--- a/src/components/EcoCounter/TrafficCounters/CounterActiveText/__tests__/__snapshots__/CounterActiveText.test.js.snap
+++ b/src/components/EcoCounter/TrafficCounters/CounterActiveText/__tests__/__snapshots__/CounterActiveText.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CounterActiveText /> should work 1`] = `
+<div>
+  <div
+    class="css-aavt1n"
+  >
+    <p
+      class="MuiTypography-root MuiTypography-body2 css-1bvqycf-MuiTypography-root"
+    >
+      Laskentatiedot ovat väliltä 01.01.2020 - 10.10.2023
+    </p>
+  </div>
+</div>
+`;

--- a/src/components/EcoCounter/TrafficCounters/CounterActiveText/index.js
+++ b/src/components/EcoCounter/TrafficCounters/CounterActiveText/index.js
@@ -1,0 +1,3 @@
+import CounterActiveText from './CounterActiveText';
+
+export default CounterActiveText;

--- a/src/components/EcoCounter/TrafficCounters/EcoCounterContent/EcoCounterContent.js
+++ b/src/components/EcoCounter/TrafficCounters/EcoCounterContent/EcoCounterContent.js
@@ -33,9 +33,10 @@ import {
   fetchInitialWeekDatas,
   fetchSelectedYearData,
 } from '../../EcoCounterRequests/ecoCounterRequests';
-import { formatDates, formatFullDates, formatMonths } from '../../utils';
+import { formatDates, formatMonths } from '../../utils';
 import LineChart from '../../LineChart';
 import InputDate from '../../InputDate';
+import CounterActiveText from '../CounterActiveText';
 
 const CustomInput = forwardRef((props, ref) => <InputDate {...props} ref={ref} />);
 
@@ -65,7 +66,6 @@ const EcoCounterContent = ({ classes, intl, station }) => {
   const stationSource = station?.csv_data_source;
   const dataFrom = station?.data_from_date;
   const dataUntil = station?.data_until_date;
-  const isActiveStation = station?.is_active?.['30'];
 
   /** When all 3 user types are rendered, a reverse order is required where 'at' is placed last */
   const reverseUserTypes = () => {
@@ -497,29 +497,6 @@ const EcoCounterContent = ({ classes, intl, station }) => {
     return input;
   };
 
-  /**
-   * Render text on 2 Telraam stations that are currently inactive and do not collect new data.
-   * @returns JSX element
-   */
-  const renderOldStationText = () => {
-    const dataFromFormat = formatDates(dataFrom);
-    const dataUntilFormat = formatFullDates(dataUntil);
-
-    if (!isActiveStation) {
-      return (
-        <div className={classes.missingDataText}>
-          <Typography variant="body2" sx={{ mb: '0.5rem', fontWeight: 'bold' }}>
-            {intl.formatMessage(
-              { id: 'ecocounter.station.active.period' },
-              { value1: dataFromFormat, value2: dataUntilFormat },
-            )}
-          </Typography>
-        </div>
-      );
-    }
-    return null;
-  };
-
   return (
     <>
       <div className={`${classes.trafficCounterHeader} ${isNarrow ? classes.widthSm : classes.widthMd}`}>
@@ -549,7 +526,7 @@ const EcoCounterContent = ({ classes, intl, station }) => {
             </div>
           ))}
         </div>
-        {stationSource === 'TR' ? renderOldStationText() : null}
+        <CounterActiveText dataFrom={dataFrom} dataUntil={dataUntil} />
         <div className={classes.trafficCounterChart}>
           <LineChart
             labels={ecoCounterLabels}

--- a/src/components/EcoCounter/TrafficCounters/LamCounterContent/LamCounterContent.js
+++ b/src/components/EcoCounter/TrafficCounters/LamCounterContent/LamCounterContent.js
@@ -33,6 +33,7 @@ import {
 import { formatDates, formatMonths } from '../../utils';
 import LineChart from '../../LineChart';
 import InputDate from '../../InputDate';
+import CounterActiveText from '../CounterActiveText';
 
 const CustomInput = forwardRef((props, ref) => <InputDate {...props} ref={ref} />);
 
@@ -416,6 +417,7 @@ const LamCounterContent = ({ classes, intl, station }) => {
             </Typography>
           </div>
         ) : null}
+        <CounterActiveText dataFrom={dataFrom} dataUntil={dataUntil} />
         <div className={classes.trafficCounterChart}>
           <LineChart
             labels={lamCounterLabels}

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -1032,6 +1032,7 @@ const translations = {
   'ecocounter.nov': 'November',
   'ecocounter.dec': 'December',
   'ecocounter.station.active.period': 'Measurement point was in use {value1} - {value2}.',
+  'ecocounter.station.counts.period': 'Havaintodata on väliltä {value1} - {value2}', // TODO translate
   'trafficCounter.year.warning.text': 'Numbers from the year {value} are not available.',
 };
 

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -1031,7 +1031,7 @@ const translations = {
   'ecocounter.oct': 'October',
   'ecocounter.nov': 'November',
   'ecocounter.dec': 'December',
-  'ecocounter.station.counts.period': 'Havaintodata on väliltä {value1} - {value2}', // TODO translate
+  'ecocounter.station.counts.period': 'Calculation data is between {value1} and {value2}',
   'trafficCounter.year.warning.text': 'Numbers from the year {value} are not available.',
 };
 

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -1031,7 +1031,6 @@ const translations = {
   'ecocounter.oct': 'October',
   'ecocounter.nov': 'November',
   'ecocounter.dec': 'December',
-  'ecocounter.station.active.period': 'Measurement point was in use {value1} - {value2}.',
   'ecocounter.station.counts.period': 'Havaintodata on väliltä {value1} - {value2}', // TODO translate
   'trafficCounter.year.warning.text': 'Numbers from the year {value} are not available.',
 };

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -1031,7 +1031,7 @@ const translations = {
   'ecocounter.oct': 'October',
   'ecocounter.nov': 'November',
   'ecocounter.dec': 'December',
-  'ecocounter.station.counts.period': 'Calculation data is between {value1} and {value2}',
+  'ecocounter.station.counts.period': 'Calculation data ranges from {value1} to {value2}',
   'trafficCounter.year.warning.text': 'Numbers from the year {value} are not available.',
 };
 

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -1026,7 +1026,6 @@ const translations = {
   'ecocounter.oct': 'Loka',
   'ecocounter.nov': 'Marras',
   'ecocounter.dec': 'Joulu',
-  'ecocounter.station.active.period': 'Laskentapiste oli käytössä {value1} - {value2}.',
   'ecocounter.station.counts.period': 'Havaintodata on väliltä {value1} - {value2}', // TODO verify
   'trafficCounter.year.warning.text': 'Vuoden {value} lukuja ei ole saatavilla.',
 };

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -1026,7 +1026,7 @@ const translations = {
   'ecocounter.oct': 'Loka',
   'ecocounter.nov': 'Marras',
   'ecocounter.dec': 'Joulu',
-  'ecocounter.station.counts.period': 'Havaintodata on väliltä {value1} - {value2}', // TODO verify
+  'ecocounter.station.counts.period': 'Laskentatiedot ovat väliltä {value1} - {value2}',
   'trafficCounter.year.warning.text': 'Vuoden {value} lukuja ei ole saatavilla.',
 };
 

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -1027,6 +1027,7 @@ const translations = {
   'ecocounter.nov': 'Marras',
   'ecocounter.dec': 'Joulu',
   'ecocounter.station.active.period': 'Laskentapiste oli käytössä {value1} - {value2}.',
+  'ecocounter.station.counts.period': 'Havaintodata on väliltä {value1} - {value2}', // TODO verify
   'trafficCounter.year.warning.text': 'Vuoden {value} lukuja ei ole saatavilla.',
 };
 

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -1034,7 +1034,7 @@ const translations = {
   'ecocounter.oct': 'Oktober',
   'ecocounter.nov': 'November',
   'ecocounter.dec': 'December',
-  'ecocounter.station.counts.period': 'Beräkningsdata är mellan {value1} - {value2}',
+  'ecocounter.station.counts.period': 'Beräkningsdata är mellan {value1} och {value2}',
   'trafficCounter.year.warning.text': 'Siffror från år {value} är inte tillgängliga.',
 };
 

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -1034,7 +1034,7 @@ const translations = {
   'ecocounter.oct': 'Oktober',
   'ecocounter.nov': 'November',
   'ecocounter.dec': 'December',
-  'ecocounter.station.counts.period': 'Havaintodata on väliltä {value1} - {value2}', // TODO translate
+  'ecocounter.station.counts.period': 'Beräkningsdata är mellan {value1} - {value2}',
   'trafficCounter.year.warning.text': 'Siffror från år {value} är inte tillgängliga.',
 };
 

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -1034,7 +1034,6 @@ const translations = {
   'ecocounter.oct': 'Oktober',
   'ecocounter.nov': 'November',
   'ecocounter.dec': 'December',
-  'ecocounter.station.active.period': 'Beräkningspunkt var i bruk {value1} - {value2}.',
   'ecocounter.station.counts.period': 'Havaintodata on väliltä {value1} - {value2}', // TODO translate
   'trafficCounter.year.warning.text': 'Siffror från år {value} är inte tillgängliga.',
 };

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -1035,6 +1035,7 @@ const translations = {
   'ecocounter.nov': 'November',
   'ecocounter.dec': 'December',
   'ecocounter.station.active.period': 'Beräkningspunkt var i bruk {value1} - {value2}.',
+  'ecocounter.station.counts.period': 'Havaintodata on väliltä {value1} - {value2}', // TODO translate
   'trafficCounter.year.warning.text': 'Siffror från år {value} är inte tillgängliga.',
 };
 


### PR DESCRIPTION
# Render text about counters

## Render text that shows first and latest dates that contain counter data.

### Trello card 568

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Render new text
 1. src/components/EcoCounter/TrafficCounters/CounterActiveText/CounterActiveText.js
     * Render text that shows first date that's contains counter data and the current latest day. These dates vary per station. Uses dataFrom & dataUntil props. Styled using styled components approach.
   
 2. src/components/EcoCounter/TrafficCounters/CounterActiveText/__tests__/CounterActiveText.test.js
     * Add tests.
    
 3. src/components/EcoCounter/TrafficCounters/EcoCounterContent/EcoCounterContent.js
     * Remove now obsolete function that returned similar text & use the new component instead.
     
 4. src/components/EcoCounter/TrafficCounters/LamCounterContent/LamCounterContent.js
     * Use the new component to render info.

#### Update texts
 1. src/i18n/en.js & src/i18n/fi.js & src/i18n/sv.js
     * Add next text.
   