### PR TITLE
Feature/park and ride stops

### DIFF
--- a/src/components/MobilityPlatform/BikeServiceStations/components/BikeServiceStationContent/__tests__/__snapshots__/BikeServiceStationContent.test.js.snap
+++ b/src/components/MobilityPlatform/BikeServiceStations/components/BikeServiceStationContent/__tests__/__snapshots__/BikeServiceStationContent.test.js.snap
@@ -9,7 +9,7 @@ exports[`<BikeServiceStationContent /> should match snapshot 1`] = `
       class="BikeServiceStationContent-headerContainer-2"
     >
       <div
-        class="injectIntl(TextComponent)-margin-6"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
@@ -22,7 +22,7 @@ exports[`<BikeServiceStationContent /> should match snapshot 1`] = `
       class="BikeServiceStationContent-textContainer-3"
     >
       <div
-        class="injectIntl(TextComponent)-margin-6"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
@@ -31,7 +31,7 @@ exports[`<BikeServiceStationContent /> should match snapshot 1`] = `
         </p>
       </div>
       <div
-        class="injectIntl(TextComponent)-margin-6"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"

--- a/src/components/MobilityPlatform/ChargerStationMarkers/components/ChargerStationContent/__tests__/__snapshots__/ChargerStationContent.test.js.snap
+++ b/src/components/MobilityPlatform/ChargerStationMarkers/components/ChargerStationContent/__tests__/__snapshots__/ChargerStationContent.test.js.snap
@@ -9,7 +9,7 @@ exports[`<ChargerStationContent /> should match snapshot 1`] = `
       class="injectIntl(ChargerStationContent)-headerContainer-2"
     >
       <div
-        class="injectIntl(TextComponent)-margin-6"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
@@ -22,7 +22,7 @@ exports[`<ChargerStationContent /> should match snapshot 1`] = `
       class="injectIntl(ChargerStationContent)-textContainer-3"
     >
       <div
-        class="injectIntl(TextComponent)-margin-6"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
@@ -31,7 +31,7 @@ exports[`<ChargerStationContent /> should match snapshot 1`] = `
         </p>
       </div>
       <div
-        class="injectIntl(TextComponent)-margin-6"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"

--- a/src/components/MobilityPlatform/LoadingPlaces/components/LoadingPlacesContent/__tests__/__snapshots__/LoadingPlacesContent.test.js.snap
+++ b/src/components/MobilityPlatform/LoadingPlaces/components/LoadingPlacesContent/__tests__/__snapshots__/LoadingPlacesContent.test.js.snap
@@ -12,7 +12,7 @@ exports[`<LoadingPlacesContent /> should match snapshot 1`] = `
         class="LoadingPlacesContent-headerContainer-2"
       >
         <div
-          class="injectIntl(TextComponent)-margin-7"
+          class="css-qpxa1n"
         >
           <p
             class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
@@ -25,7 +25,7 @@ exports[`<LoadingPlacesContent /> should match snapshot 1`] = `
         class="LoadingPlacesContent-textContainer-3"
       >
         <div
-          class="injectIntl(TextComponent)-margin-7"
+          class="css-qpxa1n"
         >
           <p
             class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
@@ -34,7 +34,7 @@ exports[`<LoadingPlacesContent /> should match snapshot 1`] = `
           </p>
         </div>
         <div
-          class="injectIntl(TextComponent)-margin-7"
+          class="css-qpxa1n"
         >
           <p
             class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
@@ -43,7 +43,7 @@ exports[`<LoadingPlacesContent /> should match snapshot 1`] = `
           </p>
         </div>
         <div
-          class="injectIntl(TextComponent)-margin-7"
+          class="css-qpxa1n"
         >
           <p
             class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
@@ -52,7 +52,7 @@ exports[`<LoadingPlacesContent /> should match snapshot 1`] = `
           </p>
         </div>
         <div
-          class="injectIntl(TextComponent)-margin-7"
+          class="css-qpxa1n"
         >
           <p
             class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"

--- a/src/components/MobilityPlatform/OutdoorGymDevices/components/OutdoorGymDevicesContent/__tests__/__snapshots__/OutdoorGymDevicesContent.test.js.snap
+++ b/src/components/MobilityPlatform/OutdoorGymDevices/components/OutdoorGymDevicesContent/__tests__/__snapshots__/OutdoorGymDevicesContent.test.js.snap
@@ -9,7 +9,7 @@ exports[`<OutdoorGymDevicesContent /> should match snapshot 1`] = `
       class="OutdoorGymDevicesContent-headerContainer-2"
     >
       <div
-        class="injectIntl(TextComponent)-margin-7"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
@@ -22,7 +22,7 @@ exports[`<OutdoorGymDevicesContent /> should match snapshot 1`] = `
       class="OutdoorGymDevicesContent-textContainer-3"
     >
       <div
-        class="injectIntl(TextComponent)-margin-7"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
@@ -31,7 +31,7 @@ exports[`<OutdoorGymDevicesContent /> should match snapshot 1`] = `
         </p>
       </div>
       <div
-        class="injectIntl(TextComponent)-margin-7"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"

--- a/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/ParkAndRideBikes.js
+++ b/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/ParkAndRideBikes.js
@@ -1,0 +1,56 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useEffect, useState } from 'react';
+import { useMap } from 'react-leaflet';
+import { useSelector } from 'react-redux';
+import bicycleStandIcon from 'servicemap-ui-turku/assets/icons/icons-icon_bicycle-stand.svg';
+import bicycleStandIconBw from 'servicemap-ui-turku/assets/icons/contrast/icons-icon_bicycle_stand-bw.svg';
+import { useMobilityPlatformContext } from '../../../../context/MobilityPlatformContext';
+import { useAccessibleMap } from '../../../../redux/selectors/settings';
+import { fetchMobilityMapData } from '../../mobilityPlatformRequests/mobilityPlatformRequests';
+import { createIcon, isDataValid, fitToMapBounds } from '../../utils/utils';
+import MarkerComponent from '../../MarkerComponent';
+
+/**
+ * Displays park and ride stops for bikes on the map in marker format.
+ */
+const ParkAndRideBikes = () => {
+  const [parkAndRideBikesData, setParkAndRideBikesData] = useState([]);
+
+  const { showParkAndRideBikes } = useMobilityPlatformContext();
+
+  const { icon } = global.L;
+
+  const useContrast = useSelector(useAccessibleMap);
+
+  const customIcon = icon(createIcon(useContrast ? bicycleStandIconBw : bicycleStandIcon));
+
+  useEffect(() => {
+    const options = {
+      type_name: 'FoliParkAndRideBikesStop',
+      page_size: 100,
+    };
+    if (showParkAndRideBikes) {
+      fetchMobilityMapData(options, setParkAndRideBikesData);
+    }
+  }, [showParkAndRideBikes]);
+
+  const map = useMap();
+
+  const renderData = isDataValid(showParkAndRideBikes, parkAndRideBikesData);
+
+  useEffect(() => {
+    fitToMapBounds(renderData, parkAndRideBikesData, map);
+  }, [showParkAndRideBikes, parkAndRideBikesData]);
+
+  return (
+    renderData
+      ? parkAndRideBikesData.map(item => (
+        <MarkerComponent key={item.id} item={item} icon={customIcon}>
+          <p>{item.name}</p>
+        </MarkerComponent>
+      ))
+      : null
+  );
+};
+
+export default ParkAndRideBikes;

--- a/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/ParkAndRideBikes.js
+++ b/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/ParkAndRideBikes.js
@@ -2,8 +2,8 @@
 import React, { useEffect, useState } from 'react';
 import { useMap } from 'react-leaflet';
 import { useSelector } from 'react-redux';
-import bicycleStandIcon from 'servicemap-ui-turku/assets/icons/icons-icon_bicycle-stand.svg';
-import bicycleStandIconBw from 'servicemap-ui-turku/assets/icons/contrast/icons-icon_bicycle_stand-bw.svg';
+import parkAndRideIcon from 'servicemap-ui-turku/assets/icons/icons-icon_park_and_ride_bicycle.svg';
+import parkAndRideIconBw from 'servicemap-ui-turku/assets/icons/contrast/icons-icon_park_and_ride_bicycle-bw.svg';
 import { useMobilityPlatformContext } from '../../../../context/MobilityPlatformContext';
 import { useAccessibleMap } from '../../../../redux/selectors/settings';
 import { fetchMobilityMapData } from '../../mobilityPlatformRequests/mobilityPlatformRequests';
@@ -23,7 +23,7 @@ const ParkAndRideBikes = () => {
 
   const useContrast = useSelector(useAccessibleMap);
 
-  const customIcon = icon(createIcon(useContrast ? bicycleStandIconBw : bicycleStandIcon));
+  const customIcon = icon(createIcon(useContrast ? parkAndRideIconBw : parkAndRideIcon));
 
   useEffect(() => {
     const options = {

--- a/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/ParkAndRideBikes.js
+++ b/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/ParkAndRideBikes.js
@@ -9,6 +9,7 @@ import { useAccessibleMap } from '../../../../redux/selectors/settings';
 import { fetchMobilityMapData } from '../../mobilityPlatformRequests/mobilityPlatformRequests';
 import { createIcon, isDataValid, fitToMapBounds } from '../../utils/utils';
 import MarkerComponent from '../../MarkerComponent';
+import ParkAndRideBikesContent from './components/ParkAndRideBikesContent';
 
 /**
  * Displays park and ride stops for bikes on the map in marker format.
@@ -46,7 +47,7 @@ const ParkAndRideBikes = () => {
     renderData
       ? parkAndRideBikesData.map(item => (
         <MarkerComponent key={item.id} item={item} icon={customIcon}>
-          <p>{item.name}</p>
+          <ParkAndRideBikesContent item={item} />
         </MarkerComponent>
       ))
       : null

--- a/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/ParkAndRideBikesContent.js
+++ b/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/ParkAndRideBikesContent.js
@@ -13,10 +13,22 @@ const ParkAndRideBikesContent = ({ item }) => {
     sv: item.name_sv,
   };
 
+  /**
+   * Take string (like kaarina) and return the same string with first character in uppercase.
+   * @param {*string} str
+   * @returns string
+   */
+  const toSentenceCase = str => {
+    if (str) {
+      return str.charAt(0).toUpperCase() + str.slice(1);
+    }
+    return '';
+  };
+
   const itemAddress = {
-    fi: `${item.address_fi}, ${item.address_zip} ${item.municipality}`,
-    en: `${item.address_en}, ${item.address_zip} ${item.municipality}`,
-    sv: `${item.address_sv}, ${item.address_zip} ${item.municipality}`,
+    fi: `${item.address_fi}, ${item.address_zip} ${toSentenceCase(item.municipality)}`,
+    en: `${item.address_en}, ${item.address_zip} ${toSentenceCase(item.municipality)}`,
+    sv: `${item.address_sv}, ${item.address_zip} ${toSentenceCase(item.municipality)}`,
   };
 
   const loadingPlaceInfo = (

--- a/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/ParkAndRideBikesContent.js
+++ b/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/ParkAndRideBikesContent.js
@@ -31,7 +31,7 @@ const ParkAndRideBikesContent = ({ item }) => {
     sv: `${item.address_sv}, ${item.address_zip} ${toSentenceCase(item.municipality)}`,
   };
 
-  const loadingPlaceInfo = (
+  const parkAndRideInfo = (
     <StyledContainer>
       <StyledHeaderContainer>
         <TextComponent textObj={itemName} isTitle />
@@ -49,7 +49,7 @@ const ParkAndRideBikesContent = ({ item }) => {
     </StyledContainer>
   );
 
-  return <StyledContainer>{loadingPlaceInfo}</StyledContainer>;
+  return <StyledContainer>{parkAndRideInfo}</StyledContainer>;
 };
 
 const StyledContainer = styled.div(({ theme }) => ({

--- a/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/ParkAndRideBikesContent.js
+++ b/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/ParkAndRideBikesContent.js
@@ -1,0 +1,78 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from '@emotion/styled';
+import { Typography } from '@mui/material';
+import { useIntl } from 'react-intl';
+import TextComponent from '../../../../TextComponent';
+
+const ParkAndRideBikesContent = ({ item }) => {
+  const intl = useIntl();
+  const itemName = {
+    fi: item.name_fi,
+    en: item.name_en,
+    sv: item.name_sv,
+  };
+
+  const itemAddress = {
+    fi: `${item.address_fi}, ${item.address_zip} ${item.municipality}`,
+    en: `${item.address_en}, ${item.address_zip} ${item.municipality}`,
+    sv: `${item.address_sv}, ${item.address_zip} ${item.municipality}`,
+  };
+
+  const loadingPlaceInfo = (
+    <StyledContainer>
+      <StyledHeaderContainer>
+        <TextComponent textObj={itemName} isTitle />
+      </StyledHeaderContainer>
+      <StyledTextContainer>
+        <StyledMargin>
+          <Typography variant="body2" component="p">
+            {intl.formatMessage({ id: 'mobilityPlatform.parkAndRide.content.subtitle' })}
+          </Typography>
+        </StyledMargin>
+        {item.address_fi !== '' ? (
+          <TextComponent messageId="mobilityPlatform.content.address" textObj={itemAddress} />
+        ) : null}
+      </StyledTextContainer>
+    </StyledContainer>
+  );
+
+  return <StyledContainer>{loadingPlaceInfo}</StyledContainer>;
+};
+
+const StyledContainer = styled.div(({ theme }) => ({
+  margin: theme.spacing(1),
+}));
+
+const StyledHeaderContainer = styled.div(({ theme }) => ({
+  width: '85%',
+  borderBottom: '1px solid #000',
+  paddingBottom: theme.spacing(0.5),
+}));
+
+const StyledTextContainer = styled.div(({ theme }) => ({
+  marginTop: theme.spacing(0.5),
+}));
+
+const StyledMargin = styled.div(({ theme }) => ({
+  margin: theme.spacing(0.4),
+}));
+
+ParkAndRideBikesContent.propTypes = {
+  item: PropTypes.shape({
+    name_fi: PropTypes.string,
+    name_en: PropTypes.string,
+    name_sv: PropTypes.string,
+    address_fi: PropTypes.string,
+    address_en: PropTypes.string,
+    address_sv: PropTypes.string,
+    address_zip: PropTypes.string,
+    municipality: PropTypes.string,
+  }),
+};
+
+ParkAndRideBikesContent.defaultProps = {
+  item: {},
+};
+
+export default ParkAndRideBikesContent;

--- a/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/__tests__/ParkAndRideBikesContent.test.js
+++ b/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/__tests__/ParkAndRideBikesContent.test.js
@@ -1,0 +1,40 @@
+/* eslint-disable react/jsx-props-no-spreading */
+// Link.react.test.js
+import React from 'react';
+import { getRenderWithProviders } from '../../../../../../../../jestUtils';
+import { initialState } from '../../../../../../../redux/reducers/user';
+import ParkAndRideBikesContent from '../index';
+import finnishTranslations from '../../../../../../../i18n/fi';
+
+const mockProps = {
+  item: {
+    name_fi: 'Testinimi',
+    name_en: 'Test name',
+    name_sv: 'Test namn',
+    address_fi: 'Testiosoite',
+    address_en: 'Test address',
+    address_sv: 'Test adress',
+    address_zip: '20200',
+    municipality: 'turku',
+  },
+};
+
+const renderWithProviders = getRenderWithProviders({
+  user: initialState,
+});
+
+describe('<ParkAndRideBikesContent />', () => {
+  it('should work', () => {
+    const { container } = renderWithProviders(<ParkAndRideBikesContent {...mockProps} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('does show text correctly', () => {
+    const { container } = renderWithProviders(<ParkAndRideBikesContent {...mockProps} />);
+
+    const p = container.querySelectorAll('p');
+    expect(p[0].textContent).toEqual('Testinimi');
+    expect(p[1].textContent).toContain(finnishTranslations['mobilityPlatform.parkAndRide.content.subtitle']);
+    expect(p[2].textContent).toEqual('Osoite: Testiosoite, 20200 Turku');
+  });
+});

--- a/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/__tests__/__snapshots__/ParkAndRideBikesContent.test.js.snap
+++ b/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/__tests__/__snapshots__/ParkAndRideBikesContent.test.js.snap
@@ -12,7 +12,7 @@ exports[`<ParkAndRideBikesContent /> should work 1`] = `
         class="css-1dznbe2"
       >
         <div
-          class="injectIntl(TextComponent)-margin-1"
+          class="css-qpxa1n"
         >
           <p
             class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
@@ -34,7 +34,7 @@ exports[`<ParkAndRideBikesContent /> should work 1`] = `
           </p>
         </div>
         <div
-          class="injectIntl(TextComponent)-margin-1"
+          class="css-qpxa1n"
         >
           <p
             class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"

--- a/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/__tests__/__snapshots__/ParkAndRideBikesContent.test.js.snap
+++ b/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/__tests__/__snapshots__/ParkAndRideBikesContent.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ParkAndRideBikesContent /> should work 1`] = `
+<div>
+  <div
+    class="css-1ynyhby"
+  >
+    <div
+      class="css-1ynyhby"
+    >
+      <div
+        class="css-1dznbe2"
+      >
+        <div
+          class="injectIntl(TextComponent)-margin-1"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
+          >
+            Testinimi
+          </p>
+        </div>
+      </div>
+      <div
+        class="css-1fhgjcy"
+      >
+        <div
+          class="css-qpxa1n"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
+          >
+            Liityntäpysäkki pyörille
+          </p>
+        </div>
+        <div
+          class="injectIntl(TextComponent)-margin-1"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
+          >
+            Osoite: Testiosoite, 20200 Turku
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/index.js
+++ b/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/index.js
@@ -1,0 +1,3 @@
+import ParkAndRideBikesContent from './ParkAndRideBikesContent';
+
+export default ParkAndRideBikesContent;

--- a/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/index.js
+++ b/src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/index.js
@@ -1,0 +1,3 @@
+import ParkAndRideBikes from './ParkAndRideBikes';
+
+export default ParkAndRideBikes;

--- a/src/components/MobilityPlatform/Parking/PublicParking/components/PublicParkingContent/__tests__/__snapshots__/PublicParkingContent.test.js.snap
+++ b/src/components/MobilityPlatform/Parking/PublicParking/components/PublicParkingContent/__tests__/__snapshots__/PublicParkingContent.test.js.snap
@@ -9,7 +9,7 @@ exports[`<PublicParkingContent /> does match snapshot 1`] = `
       class="injectIntl(PublicParkingContent)-headerContainer-2"
     >
       <div
-        class="injectIntl(TextComponent)-margin-5"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
@@ -22,7 +22,7 @@ exports[`<PublicParkingContent /> does match snapshot 1`] = `
       class="injectIntl(PublicParkingContent)-textContainer-3"
     >
       <div
-        class="injectIntl(TextComponent)-margin-5"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
@@ -49,7 +49,7 @@ exports[`<PublicParkingContent /> does match snapshot 1`] = `
         </p>
       </div>
       <div
-        class="injectIntl(TextComponent)-margin-5"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
@@ -58,7 +58,7 @@ exports[`<PublicParkingContent /> does match snapshot 1`] = `
         </p>
       </div>
       <div
-        class="injectIntl(TextComponent)-margin-5"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"

--- a/src/components/MobilityPlatform/Parking/RentalCarParking/components/RentalCarParkingContent/__tests__/__snapshots__/RentalCarParkingContent.test.js.snap
+++ b/src/components/MobilityPlatform/Parking/RentalCarParking/components/RentalCarParkingContent/__tests__/__snapshots__/RentalCarParkingContent.test.js.snap
@@ -9,7 +9,7 @@ exports[`<RentalCarParkingContent /> does match snapshot 1`] = `
       class="injectIntl(RentalCarParkingContent)-headerContainer-2"
     >
       <div
-        class="injectIntl(TextComponent)-margin-5"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-subtitle1 css-dlbwt1-MuiTypography-root"
@@ -22,7 +22,7 @@ exports[`<RentalCarParkingContent /> does match snapshot 1`] = `
       class="injectIntl(RentalCarParkingContent)-textContainer-3"
     >
       <div
-        class="injectIntl(TextComponent)-margin-5"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
@@ -49,7 +49,7 @@ exports[`<RentalCarParkingContent /> does match snapshot 1`] = `
         </p>
       </div>
       <div
-        class="injectIntl(TextComponent)-margin-5"
+        class="css-qpxa1n"
       >
         <p
           class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"

--- a/src/components/MobilityPlatform/ParkingMachines/components/ParkingMachinesContent/__tests__/__snapshots__/ParkingMachinesContent.test.js.snap
+++ b/src/components/MobilityPlatform/ParkingMachines/components/ParkingMachinesContent/__tests__/__snapshots__/ParkingMachinesContent.test.js.snap
@@ -19,7 +19,7 @@ exports[`<ParkingMachinesContent /> should match snapshot 1`] = `
         class="injectIntl(ParkingMachinesContent)-textContainer-3"
       >
         <div
-          class="injectIntl(TextComponent)-margin-5"
+          class="css-qpxa1n"
         >
           <p
             class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
@@ -28,7 +28,7 @@ exports[`<ParkingMachinesContent /> should match snapshot 1`] = `
           </p>
         </div>
         <div
-          class="injectIntl(TextComponent)-margin-5"
+          class="css-qpxa1n"
         >
           <p
             class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
@@ -46,7 +46,7 @@ exports[`<ParkingMachinesContent /> should match snapshot 1`] = `
           </p>
         </div>
         <div
-          class="injectIntl(TextComponent)-margin-5"
+          class="css-qpxa1n"
         >
           <p
             class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"

--- a/src/components/MobilityPlatform/TextComponent/TextComponent.js
+++ b/src/components/MobilityPlatform/TextComponent/TextComponent.js
@@ -1,26 +1,31 @@
 import { Typography } from '@mui/material';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { useIntl } from 'react-intl';
+import styled from '@emotion/styled';
 import useLocaleText from '../../../utils/useLocaleText';
 
 const TextComponent = ({
-  classes, intl, textObj, isTitle, messageId,
+  textObj, isTitle, messageId,
 }) => {
+  const intl = useIntl();
   const getLocaleText = useLocaleText();
   const wrapper = prop => (messageId ? intl.formatMessage({ id: messageId }, { value: prop }) : prop);
   return (
-    <div className={classes.margin}>
+    <StyledContainer>
       <Typography component="p" variant={isTitle ? 'subtitle1' : 'body2'}>
         {wrapper(getLocaleText(textObj))}
       </Typography>
-    </div>
+    </StyledContainer>
   );
 };
 
+const StyledContainer = styled.div(({ theme }) => ({
+  margin: theme.spacing(0.4),
+}));
+
 TextComponent.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.any).isRequired,
-  intl: PropTypes.objectOf(PropTypes.any).isRequired,
-  textObj: PropTypes.objectOf(PropTypes.any),
+  textObj: PropTypes.objectOf(PropTypes.string),
   isTitle: PropTypes.bool,
   messageId: PropTypes.string,
 };

--- a/src/components/MobilityPlatform/TextComponent/__tests__/__snapshots__/TextComponent.test.js.snap
+++ b/src/components/MobilityPlatform/TextComponent/__tests__/__snapshots__/TextComponent.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<TextComponent /> should match snapshot 1`] = `
 <div>
   <div
-    class="injectIntl(TextComponent)-margin-1"
+    class="css-qpxa1n"
   >
     <p
       class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"

--- a/src/components/MobilityPlatform/TextComponent/index.js
+++ b/src/components/MobilityPlatform/TextComponent/index.js
@@ -1,6 +1,3 @@
-import { withStyles } from '@mui/styles';
-import { injectIntl } from 'react-intl';
 import TextComponent from './TextComponent';
-import styles from './styles';
 
-export default withStyles(styles)(injectIntl(TextComponent));
+export default TextComponent;

--- a/src/components/MobilityPlatform/TextComponent/styles.js
+++ b/src/components/MobilityPlatform/TextComponent/styles.js
@@ -1,5 +1,0 @@
-export default theme => ({
-  margin: {
-    margin: theme.spacing(0.4),
-  },
-});

--- a/src/context/MobilityPlatformContext.js
+++ b/src/context/MobilityPlatformContext.js
@@ -40,6 +40,7 @@ const MobilityPlatformContextProvider = ({ children }) => {
   const [showBikeServiceStations, setShowBikeServiceStations] = useState(false);
   const [showCityBikes, setShowCityBikes] = useState(false);
   const [showCargoBikes, setShowCargoBikes] = useState(false);
+  const [showParkAndRideBikes, setShowParkAndRideBikes] = useState(false);
 
   // culture routes
   const [showCultureRoutes, setShowCultureRoutes] = useState(false);
@@ -117,6 +118,7 @@ const MobilityPlatformContextProvider = ({ children }) => {
     showBikeServiceStations,
     showCityBikes,
     showCargoBikes,
+    showParkAndRideBikes,
     // culture routes
     showCultureRoutes,
     cultureRouteId,
@@ -186,6 +188,7 @@ const MobilityPlatformContextProvider = ({ children }) => {
     setShowBikeServiceStations,
     setShowCityBikes,
     setShowCargoBikes,
+    setShowParkAndRideBikes,
     // culture routes
     setShowCultureRoutes,
     setCultureRouteId,

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -967,7 +967,7 @@ const translations = {
   'mobilityPlatform.info.airMonitoring.paragraph.2': 'The calculation takes into account sulfur dioxide (SO2), nitrogen dioxide (NO2), respirable particles (PM10), fine particles (PM2.5), and ozone (O3). When the air quality is poor or very poor, health effects may occur in sensitive individuals. Air quality is worsened by street dust, traffic emissions, small-scale wood combustion, energy production, and occasionally by long range transport.',
   'mobilityPlatform.info.airMonitoring.paragraph.3': 'Air quality data for the service map is obtained from the Turku region air protection co-operative group.',
   'mobilityPlatform.info.airMonitoring.link': 'For more information visit https://en.ilmatieteenlaitos.fi/air-quality',
-  'mobilityPlatform.info.parkAndRideBicycles': 'Park-and-ride arrangements provide the opportunity to leave your bicycle parked safely and hop on a bus to continue your journey. The Föli area boasts many park-and-ride sites for bicycles.  Park-and-ride parking is free and intended for those using public transport for connections.', // TODO verify
+  'mobilityPlatform.info.parkAndRideBicycles': 'Park-and-ride arrangements provide the opportunity to leave your bicycle parked safely and hop on a bus to continue your journey. The Föli area boasts many park-and-ride sites for bicycles.  Park-and-ride parking is free and intended for those using public transport for connections.',
 
   // Bicycle routes
   'mobilityPlatform.menu.bicycleRoutes.euroVelo': 'The EuroVelo 10, is the European cycle route that stretches along the Finnish costal line. The distance between Helsinki and Turku has roadside directions for the route.',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -801,6 +801,7 @@ const translations = {
   'mobilityPlatform.menu.show.roadworks': 'Roadworks',
   'mobilityPlatform.menu.show.railwayStations': 'Railway stations',
   'mobilityPlatform.menu.show.airMonitoring': 'Air quality stations',
+  'mobilityPlatform.menu.show.parkAndRideBikes': 'Park and ride stops for bicycles',
 
   // Content
   'mobilityPlatform.content.general.provider': 'Service provider: {value}',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -967,6 +967,7 @@ const translations = {
   'mobilityPlatform.info.airMonitoring.paragraph.2': 'The calculation takes into account sulfur dioxide (SO2), nitrogen dioxide (NO2), respirable particles (PM10), fine particles (PM2.5), and ozone (O3). When the air quality is poor or very poor, health effects may occur in sensitive individuals. Air quality is worsened by street dust, traffic emissions, small-scale wood combustion, energy production, and occasionally by long range transport.',
   'mobilityPlatform.info.airMonitoring.paragraph.3': 'Air quality data for the service map is obtained from the Turku region air protection co-operative group.',
   'mobilityPlatform.info.airMonitoring.link': 'For more information visit https://en.ilmatieteenlaitos.fi/air-quality',
+  'mobilityPlatform.info.parkAndRideBicycles': 'Park-and-ride arrangements provide the opportunity to leave your bicycle parked safely and hop on a bus to continue your journey. The Föli area boasts many park-and-ride sites for bicycles.  Park-and-ride parking is free and intended for those using public transport for connections.', // TODO verify
 
   // Bicycle routes
   'mobilityPlatform.menu.bicycleRoutes.euroVelo': 'The EuroVelo 10, is the European cycle route that stretches along the Finnish costal line. The distance between Helsinki and Turku has roadside directions for the route.',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -907,6 +907,7 @@ const translations = {
   'mobilityPlatform.content.arrivingTrains.title': 'Incoming trains',
   'mobilityPlatform.content.departingTrains.empty': 'No departing trains',
   'mobilityPlatform.content.arrivingTrains.empty': 'No incoming trains',
+  'mobilityPlatform.parkAndRide.content.subtitle': 'Park and ride stop for bicycles',
 
   // Info text
   'mobilityPlatform.info.description.title': 'Route description',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -962,6 +962,7 @@ const translations = {
   'mobilityPlatform.info.airMonitoring.paragraph.2': 'Laskennassa otetaan huomioon rikkidioksidi (SO2), typpidioksidi (NO2), hengitettävät hiukkaset (PM10), pienhiukkaset (PM2,5) sekä otsoni (O3). Kun ilmanlaatu on huono tai erittäin huono, terveysvaikutukset ovat mahdollisia herkillä ihmisillä. Ilmanlaatua heikentävät katupöly, liikenteen päästöt, puun pienpoltto, energiantuotanto sekä ajoittaiset kaukokulkeumat.',
   'mobilityPlatform.info.airMonitoring.paragraph.3': 'Palvelukartan ilmanlaatutiedot saadaan Turun seudun ilmansuojelun yhteistyöryhmältä.',
   'mobilityPlatform.info.airMonitoring.link': 'Lisätietoja saa osoitteesta https://www.ilmatieteenlaitos.fi/ilmanlaatu',
+  'mobilityPlatform.info.parkAndRideBicycles': 'Liityntäpysäköinti tarjoaa mahdollisuuden jättää oma pyörä parkkiin ja jatkaa matkaa bussilla. Föli-alueella on useita liityntäpysäköintipaikkoja pyörille. Liityntäpysäköinti on maksutonta ja tarkoitettu vain joukkoliikennettä vaihtoyhteytenä käyttäville.', // TODO verify
 
   // Bicycle routes
   'mobilityPlatform.menu.bicycleRoutes.euroVelo': 'EuroVelo 10 on eurooppalainen Suomen rannikkoa seuraava polkupyöräreitti. Helsingin ja Turun välisellä matkalla reitti on merkitty opastein.',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -962,7 +962,7 @@ const translations = {
   'mobilityPlatform.info.airMonitoring.paragraph.2': 'Laskennassa otetaan huomioon rikkidioksidi (SO2), typpidioksidi (NO2), hengitettävät hiukkaset (PM10), pienhiukkaset (PM2,5) sekä otsoni (O3). Kun ilmanlaatu on huono tai erittäin huono, terveysvaikutukset ovat mahdollisia herkillä ihmisillä. Ilmanlaatua heikentävät katupöly, liikenteen päästöt, puun pienpoltto, energiantuotanto sekä ajoittaiset kaukokulkeumat.',
   'mobilityPlatform.info.airMonitoring.paragraph.3': 'Palvelukartan ilmanlaatutiedot saadaan Turun seudun ilmansuojelun yhteistyöryhmältä.',
   'mobilityPlatform.info.airMonitoring.link': 'Lisätietoja saa osoitteesta https://www.ilmatieteenlaitos.fi/ilmanlaatu',
-  'mobilityPlatform.info.parkAndRideBicycles': 'Liityntäpysäköinti tarjoaa mahdollisuuden jättää oma pyörä parkkiin ja jatkaa matkaa bussilla. Föli-alueella on useita liityntäpysäköintipaikkoja pyörille. Liityntäpysäköinti on maksutonta ja tarkoitettu vain joukkoliikennettä vaihtoyhteytenä käyttäville.', // TODO verify
+  'mobilityPlatform.info.parkAndRideBicycles': 'Liityntäpysäköinti tarjoaa mahdollisuuden jättää oma pyörä parkkiin ja jatkaa matkaa bussilla. Föli-alueella on useita liityntäpysäköintipaikkoja pyörille. Liityntäpysäköinti on maksutonta ja tarkoitettu vain joukkoliikennettä vaihtoyhteytenä käyttäville.',
 
   // Bicycle routes
   'mobilityPlatform.menu.bicycleRoutes.euroVelo': 'EuroVelo 10 on eurooppalainen Suomen rannikkoa seuraava polkupyöräreitti. Helsingin ja Turun välisellä matkalla reitti on merkitty opastein.',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -902,6 +902,7 @@ const translations = {
   'mobilityPlatform.content.arrivingTrains.title': 'Saapuvat junat',
   'mobilityPlatform.content.departingTrains.empty': 'Ei lähteviä junia',
   'mobilityPlatform.content.arrivingTrains.empty': 'Ei saapuvia junia',
+  'mobilityPlatform.parkAndRide.content.subtitle': 'Liityntäpysäkki pyörille',
 
   // Info text
   'mobilityPlatform.info.description.title': 'Tietoja reitistä',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -806,6 +806,7 @@ const translations = {
   'mobilityPlatform.menu.show.roadworks': 'Tietyömaat',
   'mobilityPlatform.menu.show.railwayStations': 'Rautatieasemat',
   'mobilityPlatform.menu.show.airMonitoring': 'Ilmanlaadun mittauspisteet',
+  'mobilityPlatform.menu.show.parkAndRideBikes': 'Liityntäpysäkit pyörille',
 
   // Content
   'mobilityPlatform.content.general.provider': 'Palveluntarjoaja: {value}',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -802,9 +802,10 @@ const translations = {
   'mobilityPlatform.menu.show.rentalCarParking': 'Bilpool bilars parkeringsplatser',
   'mobilityPlatform.menu.show.publicBenches': 'Allmänna bänkar (zooma in på kartan)',
   'mobilityPlatform.embedded.label.publicBenches': 'Allmänna bänkar (zooma in på kartan för att se bänkar)',
-  'mobilityPlatform.menu.show.airMonitoring': 'Stationer för luftkvalitet', // TODO verify
+  'mobilityPlatform.menu.show.airMonitoring': 'Stationer för luftkvalitet',
   'mobilityPlatform.menu.show.roadworks': 'Vägarbeten',
   'mobilityPlatform.menu.show.railwayStations': 'Järnvägsstationer',
+  'mobilityPlatform.menu.show.parkAndRideBikes': 'Infartsparkering för cyklar',
 
   // Content
   'mobilityPlatform.content.general.provider': 'Tjänsteleverantör: {value}',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -911,6 +911,7 @@ const translations = {
   'mobilityPlatform.content.arrivingTrains.title': 'Inkommande tåg',
   'mobilityPlatform.content.departingTrains.empty': 'Inga avgående tåg',
   'mobilityPlatform.content.arrivingTrains.empty': 'Inga inkommande tåg',
+  'mobilityPlatform.parkAndRide.content.subtitle': 'Infartspark for cyklarna',
 
   // Info text
   'mobilityPlatform.info.description.title': 'Beskrivning av rutten',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -971,6 +971,7 @@ const translations = {
   'mobilityPlatform.info.airMonitoring.paragraph.2': 'Vid beräkningen beaktas svaveldioxid (SO2), kvävedioxid (NO2), inandningsbara partiklar (PM10), småpartiklar (PM2,5) samt ozon (O3). När luftkvaliteten är dålig eller mycket dålig kan hälsopåverkan förekomma hos känsliga personer. Luftkvaliteten försämras av gatudamm, trafikutsläpp, småskalig vedeldning, energiproduktion samt av sporadiskt förekommande långväga transport.',
   'mobilityPlatform.info.airMonitoring.paragraph.3': 'Luftkvalitetsdata för Servicekartan erhålls från Åboregionens samarbetsgrupp för luftskydd.',
   'mobilityPlatform.info.airMonitoring.link': 'För mer information besök: https://sv.ilmatieteenlaitos.fi/luftkvalitet',
+  'mobilityPlatform.info.parkAndRideBicycles': 'Infartsparkeringen erbjuder möjlighet att lämna din egen cykel på parkeringsplatsen och fortsätta resan med buss. Inom Föli-området finns flera infartsparkeringsplatser för cyklar. Infartsparkeringen är gratis och endast avsedd för dem som fortsätter sin resa med kollektivtrafik.', // TODO verify
 
   // Bicycle routes
   'mobilityPlatform.menu.bicycleRoutes.euroVelo': 'EuroVelo 10 är en europeisk cykelrutt som följer den finländska kusten. Sträckan mellan Helsingfors och Åbo är skyltad.',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -971,7 +971,7 @@ const translations = {
   'mobilityPlatform.info.airMonitoring.paragraph.2': 'Vid beräkningen beaktas svaveldioxid (SO2), kvävedioxid (NO2), inandningsbara partiklar (PM10), småpartiklar (PM2,5) samt ozon (O3). När luftkvaliteten är dålig eller mycket dålig kan hälsopåverkan förekomma hos känsliga personer. Luftkvaliteten försämras av gatudamm, trafikutsläpp, småskalig vedeldning, energiproduktion samt av sporadiskt förekommande långväga transport.',
   'mobilityPlatform.info.airMonitoring.paragraph.3': 'Luftkvalitetsdata för Servicekartan erhålls från Åboregionens samarbetsgrupp för luftskydd.',
   'mobilityPlatform.info.airMonitoring.link': 'För mer information besök: https://sv.ilmatieteenlaitos.fi/luftkvalitet',
-  'mobilityPlatform.info.parkAndRideBicycles': 'Infartsparkeringen erbjuder möjlighet att lämna din egen cykel på parkeringsplatsen och fortsätta resan med buss. Inom Föli-området finns flera infartsparkeringsplatser för cyklar. Infartsparkeringen är gratis och endast avsedd för dem som fortsätter sin resa med kollektivtrafik.', // TODO verify
+  'mobilityPlatform.info.parkAndRideBicycles': 'Infartsparkeringen erbjuder möjlighet att lämna din egen cykel på parkeringsplatsen och fortsätta resan med buss. Inom Föli-området finns flera infartsparkeringsplatser för cyklar. Infartsparkeringen är gratis och endast avsedd för dem som fortsätter sin resa med kollektivtrafik.',
 
   // Bicycle routes
   'mobilityPlatform.menu.bicycleRoutes.euroVelo': 'EuroVelo 10 är en europeisk cykelrutt som följer den finländska kusten. Sträckan mellan Helsingfors och Åbo är skyltad.',

--- a/src/views/MobilityPlatformMapView/MobilityPlatformMapView.js
+++ b/src/views/MobilityPlatformMapView/MobilityPlatformMapView.js
@@ -37,6 +37,7 @@ import PublicBenches from '../../components/MobilityPlatform/PublicBenches';
 import Roadworks from '../../components/MobilityPlatform/Roadworks';
 import RailwayStations from '../../components/MobilityPlatform/RailwayStations';
 import AirMonitoring from '../../components/MobilityPlatform/EnvironmentObservations/AirMonitoring';
+import ParkAndRideBikes from '../../components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes';
 
 const MobilityPlatformMapView = ({ mapObject }) => (
   <>
@@ -77,6 +78,7 @@ const MobilityPlatformMapView = ({ mapObject }) => (
     <Roadworks />
     <RailwayStations />
     <AirMonitoring />
+    <ParkAndRideBikes />
   </>
 );
 

--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -172,6 +172,8 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
     setShowRailwayStations,
     showAirMonitoringStations,
     setShowAirMonitoringStations,
+    showParkAndRideBikes,
+    setShowParkAndRideBikes,
   } = useMobilityPlatformContext();
 
   const locale = useSelector(state => state.user.locale);
@@ -377,7 +379,8 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
     checkVisibilityValues(showBikeServiceStations, setOpenBicycleSettings);
     checkVisibilityValues(showCityBikes, setOpenBicycleSettings);
     checkVisibilityValues(showCargoBikes, setOpenBicycleSettings);
-  }, [showBicycleStands, showHullLockableStands, showBikeServiceStations, showCityBikes, showCargoBikes]);
+    checkVisibilityValues(showParkAndRideBikes, setOpenBicycleSettings);
+  }, [showBicycleStands, showHullLockableStands, showBikeServiceStations, showCityBikes, showCargoBikes, showParkAndRideBikes]);
 
   useEffect(() => {
     checkVisibilityValues(showBicycleRoutes, setOpenBicycleSettings);
@@ -848,6 +851,10 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
     setShowRoadworks(current => !current);
   };
 
+  const parkAndRideBikesToggle = () => {
+    setShowParkAndRideBikes(current => !current);
+  };
+
   const cultureRouteListToggle = () => {
     setOpenCultureRouteList(current => !current);
     if (cultureRouteId) {
@@ -1243,6 +1250,12 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
       msgId: 'mobilityPlatform.menu.showBikeServiceStations',
       checkedValue: showBikeServiceStations,
       onChangeValue: bikeServiceStationsToggle,
+    },
+    {
+      type: 'parkAndRideBikeStops',
+      msgId: 'mobilityPlatform.menu.show.parkAndRideBikes',
+      checkedValue: showParkAndRideBikes,
+      onChangeValue: parkAndRideBikesToggle,
     },
     {
       type: 'brushSandedRoute',

--- a/src/views/MobilitySettingsView/MobilitySettingsView.js
+++ b/src/views/MobilitySettingsView/MobilitySettingsView.js
@@ -1646,6 +1646,11 @@ const MobilitySettingsView = ({ classes, intl, navigator }) => {
       component: <CityBikeInfo bikeInfo={cargoBikeInfo} />,
     },
     {
+      visible: showParkAndRideBikes,
+      type: 'parkAndRideBicyclesInfo',
+      component: <InfoTextBox infoText="mobilityPlatform.info.parkAndRideBicycles" />,
+    },
+    {
       visible: showBrushSaltedRoute || showBrushSandedRoute,
       type: 'brushedRoutes',
       component: <InfoTextBox infoText="mobilityPlatform.info.streetMaintenance.brushedRoads" />,


### PR DESCRIPTION
# Show park and ride stops

## Show park and ride stops for bicycles on the map.

### Trello card 565

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Show park & ride stops
 1. src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/ParkAndRideBikes.js
     * Fetch data and display it on the map using markers. Fit data into map bounds as well.
   
 2. src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/ParkAndRideBikesContent.js
     * Render relevant content (like address) inside Leaflet popup. Use styled components approach.
    
 3. src/components/MobilityPlatform/ParkAndRideStops/ParkAndRideBikes/components/ParkAndRideBikesContent/__tests__/ParkAndRideBikesContent.test.js
     * Add unit tests.
     
 4. src/context/MobilityPlatformContext.js
     * Add new context values.

 5. src/views/MobilitySettingsView/MobilitySettingsView.js
     * Add toggle function, update the array of content types & render the new info text.

 6. src/views/MobilityPlatformMapView/MobilityPlatformMapView.js
     * Import into the map view.

 7. src/i18n/en.js & src/i18n/fi.js & src/i18n/sv.js
     * Add new texts and translations.

#### Update text component
 1. src/components/MobilityPlatform/TextComponent/TextComponent.js
     * Update text component to use styled components.
   
 2. src/components/MobilityPlatform/BikeServiceStations/components/BikeServiceStationContent/__tests__/__snapshots__/BikeServiceStationContent.test.js.snap
     * Update snapshot
    
 3. rest
      * Update snapshots
