### PR TITLE
Fix max count and icon related bug

### DIFF
--- a/src/components/MobilityPlatform/MobilityProfiles/MobilityProfiles.js
+++ b/src/components/MobilityPlatform/MobilityProfiles/MobilityProfiles.js
@@ -116,7 +116,9 @@ const MobilityProfiles = () => {
    * @returns leaflet icon
    */
   const getCorrectIcon = (nameValue, mobilityProfiles) => {
-    const filteredMobilityProfiles = mobilityProfiles?.filter(item => item.postal_code_string === nameValue);
+    const filteredMobilityProfiles = mobilityProfiles?.filter(
+      item => item.postal_code_string === nameValue && item.postal_code_type_string === 'Home',
+    );
     const maxCount = filteredMobilityProfiles?.reduce(
       (prev, current) => (prev.count > current.count ? prev : current),
       1,


### PR DESCRIPTION
# Fix max count and icon related bug

## Fix instance where `maxCount` value wasn't counted from the correct postal code type.

### Trello card 602

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Fix to bug in `getCorrectIcon` function
 1. src/components/MobilityPlatform/MobilityProfiles/MobilityProfiles.js
     * Improve filter function by adding another clause. This ensures that profile with highest count value matches the one that is on the list inside the Leaflet popup.
   
